### PR TITLE
Add Android release pipeline

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+info() {
+	printf '[INFO] %s\n' "$*" >&2
+}
+
+warn() {
+	printf '[WARN] %s\n' "$*" >&2
+}
+
+error() {
+	printf '[ERROR] %s\n' "$*" >&2
+}
+
+die() {
+	error "$*"
+	exit 1
+}
+
+require_tool() {
+	command -v "$1" >/dev/null 2>&1 || die "Required tool '$1' is not available."
+}
+
+is_zero_sha() {
+	local sha="${1:-}"
+	[[ -z "$sha" || "$sha" =~ ^0+$ ]]
+}
+
+append_unique_line() {
+	local file="$1"
+	local value="$2"
+
+	[[ -n "$value" ]] || return 0
+	if [[ ! -s "$file" ]] || ! grep -Fx "$value" "$file" >/dev/null 2>&1; then
+		printf '%s\n' "$value" >>"$file"
+	fi
+}
+
+sort_file_if_present() {
+	local file="$1"
+
+	if [[ -s "$file" ]]; then
+		sort -u "$file" -o "$file"
+	fi
+}
+
+file_to_csv() {
+	local file="$1"
+
+	if [[ -s "$file" ]]; then
+		paste -sd, "$file"
+	fi
+}
+
+file_to_space_list() {
+	local file="$1"
+
+	if [[ -s "$file" ]]; then
+		paste -sd' ' "$file"
+	fi
+}
+
+app_version_file() {
+	printf 'gradle/app-version.properties\n'
+}
+
+extract_property_from_stdin() {
+	local property_name="$1"
+	awk -F= -v key="$property_name" '
+		$1 == key {
+			value = $2
+			sub(/^[[:space:]]+/, "", value)
+			sub(/[[:space:]]+$/, "", value)
+			print value
+			exit
+		}
+	'
+}
+
+get_app_version_property() {
+	local property_name="$1"
+	local value
+
+	value="$(extract_property_from_stdin "$property_name" <"$(app_version_file)")"
+	[[ -n "$value" ]] || die "Missing app version property '${property_name}' in $(app_version_file)."
+	printf '%s\n' "$value"
+}
+
+get_app_version_name() {
+	get_app_version_property versionName
+}
+
+get_android_version_code() {
+	get_app_version_property androidVersionCode
+}
+
+get_ios_build_number() {
+	get_app_version_property iosBuildNumber
+}
+
+get_app_version_property_at_git_ref() {
+	local property_name="$1"
+	local git_ref="$2"
+	local contents
+
+	[[ -n "$git_ref" ]] || return 0
+	contents="$(git show "${git_ref}:$(app_version_file)" 2>/dev/null || true)"
+	printf '%s' "$contents" | extract_property_from_stdin "$property_name"
+}
+
+validate_semver() {
+	local version="$1"
+	[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+validate_positive_integer() {
+	local value="$1"
+	[[ "$value" =~ ^[1-9][0-9]*$ ]]
+}
+
+app_tag_name() {
+	local version="$1"
+	printf 'app-%s\n' "$version"
+}
+
+existing_tag_target() {
+	local tag_name="$1"
+
+	if git rev-parse -q --verify "refs/tags/${tag_name}" >/dev/null 2>&1; then
+		git rev-list -n 1 "$tag_name"
+	fi
+}
+
+changed_files_between_refs() {
+	local before_sha="$1"
+	local after_sha="$2"
+
+	if is_zero_sha "$before_sha"; then
+		info "Using single-commit diff because the previous SHA is empty."
+		git diff-tree --no-commit-id --name-only -r "$after_sha"
+	else
+		info "Detecting changes between ${before_sha} and ${after_sha}."
+		git diff --name-only "$before_sha" "$after_sha"
+	fi
+}

--- a/.github/scripts/deploy-production.sh
+++ b/.github/scripts/deploy-production.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+require_tool git
+require_tool jq
+
+TARGET_GIT_SHA="${TARGET_GIT_SHA:-${GITHUB_SHA:-$(git rev-parse HEAD)}}"
+DEPLOY_DIFF_BASE_SHA="${DEPLOY_DIFF_BASE_SHA:-}"
+STATE_DIR="${STATE_DIR:-$(mktemp -d "${RUNNER_TEMP:-/tmp}/tuindice-deploy.XXXXXX")}"
+DRY_RUN="${DRY_RUN:-0}"
+VERSION_NAME="$(get_app_version_name)"
+TAG_NAME="$(app_tag_name "$VERSION_NAME")"
+
+resolve_deploy_diff_base_sha() {
+	local before_sha="${DEPLOY_DIFF_BASE_SHA:-}"
+
+	if [[ -n "$before_sha" ]]; then
+		printf '%s\n' "$before_sha"
+		return
+	fi
+
+	if [[ -n "${GITHUB_EVENT_PATH:-}" && -f "${GITHUB_EVENT_PATH:-}" ]]; then
+		before_sha="$(jq -r '.before // empty' "$GITHUB_EVENT_PATH")"
+	fi
+
+	if is_zero_sha "$before_sha"; then
+		before_sha="$(git rev-parse "${TARGET_GIT_SHA}^" 2>/dev/null || true)"
+	fi
+
+	printf '%s\n' "$before_sha"
+}
+
+create_release_tag() {
+	local existing_target
+
+	existing_target="$(existing_tag_target "$TAG_NAME" || true)"
+	if [[ -n "$existing_target" ]]; then
+		if [[ "$existing_target" == "$TARGET_GIT_SHA" ]]; then
+			info "Release tag ${TAG_NAME} already exists on ${TARGET_GIT_SHA}."
+			return 0
+		fi
+		die "Release tag ${TAG_NAME} already exists at ${existing_target}. Bump $(app_version_file) before deploying."
+	fi
+
+	info "Creating release tag ${TAG_NAME} on ${TARGET_GIT_SHA}."
+	git tag -a "$TAG_NAME" "$TARGET_GIT_SHA" -m "TuIndice app ${VERSION_NAME}"
+	git push origin "refs/tags/${TAG_NAME}"
+}
+
+BEFORE_SHA="$(resolve_deploy_diff_base_sha)"
+[[ -n "$BEFORE_SHA" ]] || die "Unable to resolve previous production SHA."
+
+DETECT_STATE_DIR="${STATE_DIR}/detect"
+mkdir -p "$DETECT_STATE_DIR"
+
+STATE_DIR="$DETECT_STATE_DIR" bash "${SCRIPT_DIR}/detect-changed-app.sh" "$BEFORE_SHA" "$TARGET_GIT_SHA"
+
+ANDROID_TASKS_FILE="${DETECT_STATE_DIR}/android-gradle-tasks.txt"
+if ! grep -Fx ":app:bundleRelease" "$ANDROID_TASKS_FILE" >/dev/null 2>&1; then
+	info "No release-impacting Android changes detected. Skipping production draft deploy."
+	exit 0
+fi
+
+MISSING_VERSION_BUMP_FILE="${DETECT_STATE_DIR}/missing-version-bump.txt" \
+HAS_RELEVANT_CHANGES="true" \
+TARGET_GIT_SHA="$TARGET_GIT_SHA" \
+	bash "${SCRIPT_DIR}/preflight-production.sh"
+
+REQUIRE_FIREBASE_CONFIGS=1 bash "${SCRIPT_DIR}/materialize-firebase-configs.sh"
+export TU_INDICE_KEY_STORE_PATH="${TU_INDICE_KEY_STORE_PATH:-${RUNNER_TEMP:-/tmp}/tuindice-release.jks}"
+bash "${SCRIPT_DIR}/materialize-android-signing.sh"
+
+info "Building signed Android App Bundle."
+./gradlew --console=plain :app:bundleRelease
+
+if [[ "$DRY_RUN" == "1" ]]; then
+	info "DRY_RUN=1: skipping Google Play upload and release tag creation."
+	exit 0
+fi
+
+bash "${SCRIPT_DIR}/publish-google-play-draft.sh"
+create_release_tag
+
+info "Production deploy completed for ${VERSION_NAME} (${TAG_NAME})."

--- a/.github/scripts/detect-changed-app.sh
+++ b/.github/scripts/detect-changed-app.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+BEFORE_SHA="${1:-${GIT_BEFORE_SHA:-}}"
+AFTER_SHA="${2:-${GIT_AFTER_SHA:-${GITHUB_SHA:-HEAD}}}"
+STATE_DIR="${STATE_DIR:-$(mktemp -d "${RUNNER_TEMP:-/tmp}/tuindice-changes.XXXXXX")}"
+
+CHANGED_FILES_FILE="${CHANGED_FILES_FILE:-${STATE_DIR}/changed-files.txt}"
+MISSING_VERSION_BUMP_FILE="${MISSING_VERSION_BUMP_FILE:-${STATE_DIR}/missing-version-bump.txt}"
+ANDROID_TASKS_FILE="${ANDROID_TASKS_FILE:-${STATE_DIR}/android-gradle-tasks.txt}"
+RELEASE_IMPACTED_FILE="${RELEASE_IMPACTED_FILE:-${STATE_DIR}/release-impacted.txt}"
+
+mkdir -p "$STATE_DIR"
+: >"$CHANGED_FILES_FILE"
+: >"$MISSING_VERSION_BUMP_FILE"
+: >"$ANDROID_TASKS_FILE"
+: >"$RELEASE_IMPACTED_FILE"
+
+APP_VERSION_TOUCHED=false
+APP_VERSION_CHANGED=false
+CI_CONFIG_TOUCHED=false
+HAS_RELEVANT_CHANGES=false
+HAS_RELEASE_IMPACT=false
+
+append_android_task() {
+	append_unique_line "$ANDROID_TASKS_FILE" "$1"
+}
+
+mark_app_tested() {
+	append_android_task ":app:testDebugUnitTest"
+}
+
+mark_release_impacted() {
+	HAS_RELEASE_IMPACT=true
+	append_unique_line "$RELEASE_IMPACTED_FILE" app
+	mark_app_tested
+	append_android_task ":app:bundleRelease"
+}
+
+classify_changed_file() {
+	local file="$1"
+
+	case "$file" in
+		''|.DS_Store|*/.DS_Store)
+			return 0
+			;;
+		.github/workflows/*|.github/scripts/*|.github/actions/*)
+			CI_CONFIG_TOUCHED=true
+			HAS_RELEVANT_CHANGES=true
+			return 0
+			;;
+		"$(app_version_file)")
+			APP_VERSION_TOUCHED=true
+			HAS_RELEVANT_CHANGES=true
+			mark_release_impacted
+			return 0
+			;;
+		AGENTS.md|README.md|LICENSE|docs/*|.codex/*)
+			return 0
+			;;
+		settings.gradle|settings.gradle.kts|build.gradle|build.gradle.kts|gradle.properties|gradlew|gradlew.bat|gradle/*)
+			HAS_RELEVANT_CHANGES=true
+			mark_release_impacted
+			return 0
+			;;
+		app/src/test/*)
+			HAS_RELEVANT_CHANGES=true
+			mark_app_tested
+			return 0
+			;;
+		app/*)
+			HAS_RELEVANT_CHANGES=true
+			mark_release_impacted
+			return 0
+			;;
+		mocks/*)
+			HAS_RELEVANT_CHANGES=true
+			mark_app_tested
+			return 0
+			;;
+		*)
+			HAS_RELEVANT_CHANGES=true
+			mark_release_impacted
+			return 0
+			;;
+	esac
+}
+
+changed_files_between_refs "$BEFORE_SHA" "$AFTER_SHA" >"$CHANGED_FILES_FILE"
+
+while IFS= read -r changed_file; do
+	[[ -n "$changed_file" ]] || continue
+	classify_changed_file "$changed_file"
+done <"$CHANGED_FILES_FILE"
+
+if [[ "$APP_VERSION_TOUCHED" == "true" ]]; then
+	base_version="$(get_app_version_property_at_git_ref versionName "$BEFORE_SHA")"
+	head_version="$(get_app_version_property_at_git_ref versionName "$AFTER_SHA")"
+	base_android_code="$(get_app_version_property_at_git_ref androidVersionCode "$BEFORE_SHA")"
+	head_android_code="$(get_app_version_property_at_git_ref androidVersionCode "$AFTER_SHA")"
+	base_ios_build="$(get_app_version_property_at_git_ref iosBuildNumber "$BEFORE_SHA")"
+	head_ios_build="$(get_app_version_property_at_git_ref iosBuildNumber "$AFTER_SHA")"
+
+	if [[ "$base_version" != "$head_version" || "$base_android_code" != "$head_android_code" || "$base_ios_build" != "$head_ios_build" ]]; then
+		APP_VERSION_CHANGED=true
+	fi
+fi
+
+if [[ "$HAS_RELEASE_IMPACT" == "true" && "$APP_VERSION_CHANGED" != "true" ]]; then
+	append_unique_line "$MISSING_VERSION_BUMP_FILE" app
+fi
+
+if [[ "$APP_VERSION_CHANGED" == "true" ]]; then
+	HAS_RELEVANT_CHANGES=true
+	mark_release_impacted
+fi
+
+if [[ "$CI_CONFIG_TOUCHED" == "true" ]]; then
+	append_android_task "verifyAppVersionSync"
+fi
+
+sort_file_if_present "$MISSING_VERSION_BUMP_FILE"
+sort_file_if_present "$ANDROID_TASKS_FILE"
+sort_file_if_present "$RELEASE_IMPACTED_FILE"
+
+info "Changed files: $(file_to_csv "$CHANGED_FILES_FILE" || true)"
+info "App version touched: ${APP_VERSION_TOUCHED}"
+info "App version changed: ${APP_VERSION_CHANGED}"
+info "Missing version bump: $(file_to_csv "$MISSING_VERSION_BUMP_FILE" || true)"
+info "CI/CD configuration touched: ${CI_CONFIG_TOUCHED}"
+info "Android Gradle tasks: $(file_to_space_list "$ANDROID_TASKS_FILE" || true)"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	{
+		printf 'state_dir=%s\n' "$STATE_DIR"
+		printf 'changed_files_file=%s\n' "$CHANGED_FILES_FILE"
+		printf 'missing_version_bump_file=%s\n' "$MISSING_VERSION_BUMP_FILE"
+		printf 'missing_version_bump_csv=%s\n' "$(file_to_csv "$MISSING_VERSION_BUMP_FILE" || true)"
+		printf 'release_impacted_file=%s\n' "$RELEASE_IMPACTED_FILE"
+		printf 'release_impacted_csv=%s\n' "$(file_to_csv "$RELEASE_IMPACTED_FILE" || true)"
+		printf 'android_tasks=%s\n' "$(file_to_space_list "$ANDROID_TASKS_FILE" || true)"
+		printf 'android_tasks_file=%s\n' "$ANDROID_TASKS_FILE"
+		printf 'app_version_touched=%s\n' "$APP_VERSION_TOUCHED"
+		printf 'app_version_changed=%s\n' "$APP_VERSION_CHANGED"
+		printf 'ci_config_touched=%s\n' "$CI_CONFIG_TOUCHED"
+		printf 'has_relevant_changes=%s\n' "$HAS_RELEVANT_CHANGES"
+		printf 'has_release_impact=%s\n' "$HAS_RELEASE_IMPACT"
+	} >>"$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/materialize-android-signing.sh
+++ b/.github/scripts/materialize-android-signing.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+decode_base64_to_file() {
+	local value="$1"
+	local target_file="$2"
+
+	mkdir -p "$(dirname "$target_file")"
+	if base64 --help 2>/dev/null | grep -q -- '--decode'; then
+		printf '%s' "$value" | base64 --decode >"$target_file"
+	else
+		printf '%s' "$value" | base64 -D >"$target_file"
+	fi
+	chmod 600 "$target_file"
+}
+
+if [[ -n "${ANDROID_RELEASE_KEYSTORE_BASE64:-}" ]]; then
+	TU_INDICE_KEY_STORE_PATH="${TU_INDICE_KEY_STORE_PATH:-${RUNNER_TEMP:-/tmp}/tuindice-release.jks}"
+	info "Materializing Android release keystore."
+	decode_base64_to_file "$ANDROID_RELEASE_KEYSTORE_BASE64" "$TU_INDICE_KEY_STORE_PATH"
+fi
+
+[[ -n "${TU_INDICE_KEY_STORE_PATH:-}" ]] || die "TU_INDICE_KEY_STORE_PATH or ANDROID_RELEASE_KEYSTORE_BASE64 is required."
+[[ -s "$TU_INDICE_KEY_STORE_PATH" ]] || die "Android release keystore not found at ${TU_INDICE_KEY_STORE_PATH}."
+[[ -n "${TU_INDICE_KEY_ALIAS:-}" ]] || die "TU_INDICE_KEY_ALIAS is required."
+[[ -n "${TU_INDICE_KEY_PASSWORD:-}" ]] || die "TU_INDICE_KEY_PASSWORD is required."
+[[ -n "${TU_INDICE_KEY_STORE_PASSWORD:-}" ]] || die "TU_INDICE_KEY_STORE_PASSWORD is required."
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+	printf 'TU_INDICE_KEY_STORE_PATH=%s\n' "$TU_INDICE_KEY_STORE_PATH" >>"$GITHUB_ENV"
+fi
+
+info "Android release signing inputs are available."

--- a/.github/scripts/materialize-firebase-configs.sh
+++ b/.github/scripts/materialize-firebase-configs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+decode_base64_to_file() {
+	local value="$1"
+	local target_file="$2"
+
+	mkdir -p "$(dirname "$target_file")"
+	if base64 --help 2>/dev/null | grep -q -- '--decode'; then
+		printf '%s' "$value" | base64 --decode >"$target_file"
+	else
+		printf '%s' "$value" | base64 -D >"$target_file"
+	fi
+}
+
+if [[ -n "${ANDROID_GOOGLE_SERVICES_JSON_BASE64:-}" ]]; then
+	info "Materializing Android Firebase configuration."
+	decode_base64_to_file "$ANDROID_GOOGLE_SERVICES_JSON_BASE64" "app/google-services.json"
+fi
+
+if [[ -n "${IOS_GOOGLE_SERVICE_INFO_PLIST_BASE64:-}" ]]; then
+	if [[ -d "iosApp/Resources" ]]; then
+		info "Materializing iOS Firebase configuration."
+		decode_base64_to_file "$IOS_GOOGLE_SERVICE_INFO_PLIST_BASE64" "iosApp/Resources/GoogleService-Info.plist"
+	else
+		warn "IOS_GOOGLE_SERVICE_INFO_PLIST_BASE64 is present, but iosApp/Resources does not exist on this branch. Skipping iOS Firebase config."
+	fi
+fi
+
+if [[ "${REQUIRE_FIREBASE_CONFIGS:-0}" == "1" ]]; then
+	[[ -s app/google-services.json ]] || die "Missing app/google-services.json. Provide ANDROID_GOOGLE_SERVICES_JSON_BASE64."
+fi
+
+if [[ "${REQUIRE_IOS_FIREBASE_CONFIG:-0}" == "1" ]]; then
+	[[ -s iosApp/Resources/GoogleService-Info.plist ]] || die "Missing iosApp/Resources/GoogleService-Info.plist. Provide IOS_GOOGLE_SERVICE_INFO_PLIST_BASE64."
+fi

--- a/.github/scripts/preflight-production.sh
+++ b/.github/scripts/preflight-production.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+require_tool git
+
+MISSING_VERSION_BUMP_FILE="${MISSING_VERSION_BUMP_FILE:-}"
+HAS_RELEVANT_CHANGES="${HAS_RELEVANT_CHANGES:-true}"
+SUMMARY_FILE="${SUMMARY_FILE:-${GITHUB_STEP_SUMMARY:-${RUNNER_TEMP:-/tmp}/preflight-production-summary.md}}"
+TARGET_GIT_SHA="${TARGET_GIT_SHA:-${GITHUB_SHA:-$(git rev-parse HEAD)}}"
+
+file_has_entries() {
+	local file="${1:-}"
+	[[ -n "$file" && -s "$file" ]]
+}
+
+join_file_lines_as_csv() {
+	local file="$1"
+
+	if file_has_entries "$file"; then
+		paste -sd, "$file"
+	fi
+}
+
+write_summary() {
+	{
+		printf '## Production preflight summary\n\n'
+		printf -- '- Target SHA: `%s`\n' "$TARGET_GIT_SHA"
+		printf -- '- App version: `%s`\n' "$(get_app_version_name)"
+		printf -- '- Android version code: `%s`\n' "$(get_android_version_code)"
+		printf -- '- Reserved iOS build number: `%s`\n' "$(get_ios_build_number)"
+		if file_has_entries "$MISSING_VERSION_BUMP_FILE"; then
+			printf -- '- Missing version bump: `%s`\n' "$(join_file_lines_as_csv "$MISSING_VERSION_BUMP_FILE")"
+		else
+			printf -- '- Missing version bump: none\n'
+		fi
+		printf -- '- Local E2E certification: not required on the legacy Android production branch\n'
+	} >>"$SUMMARY_FILE"
+}
+
+if [[ "$HAS_RELEVANT_CHANGES" != "true" ]]; then
+	info "No relevant app release changes detected. Preflight exits successfully."
+	write_summary
+	exit 0
+fi
+
+bash "${SCRIPT_DIR}/validate-app-version.sh"
+
+if file_has_entries "$MISSING_VERSION_BUMP_FILE"; then
+	die "Runtime app changes were detected, but $(app_version_file) did not change. Bump versionName/androidVersionCode before deploying."
+fi
+
+write_summary
+info "Production preflight checks passed."

--- a/.github/scripts/publish-google-play-draft.sh
+++ b/.github/scripts/publish-google-play-draft.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+require_tool curl
+require_tool jq
+
+ANDROID_PACKAGE_NAME="${ANDROID_PACKAGE_NAME:-com.gdavidpb.tuindice}"
+GOOGLE_PLAY_TRACK="${GOOGLE_PLAY_TRACK:-production}"
+ANDROID_AAB_PATH="${ANDROID_AAB_PATH:-app/build/outputs/bundle/release/app-release.aab}"
+ACCESS_TOKEN="${ANDROID_PUBLISHER_ACCESS_TOKEN:-${GOOGLE_OAUTH_ACCESS_TOKEN:-}}"
+VERSION_NAME="$(get_app_version_name)"
+ANDROID_VERSION_CODE="$(get_android_version_code)"
+API_ROOT="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${ANDROID_PACKAGE_NAME}"
+UPLOAD_ROOT="https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications/${ANDROID_PACKAGE_NAME}"
+
+[[ -n "$ACCESS_TOKEN" ]] || die "ANDROID_PUBLISHER_ACCESS_TOKEN or GOOGLE_OAUTH_ACCESS_TOKEN is required."
+[[ -s "$ANDROID_AAB_PATH" ]] || die "Android App Bundle not found: ${ANDROID_AAB_PATH}"
+
+api_post() {
+	local url="$1"
+	curl --fail --silent --show-error \
+		-X POST \
+		-H "Authorization: Bearer ${ACCESS_TOKEN}" \
+		-H "Accept: application/json" \
+		"$url"
+}
+
+api_put_json() {
+	local url="$1"
+	local json_file="$2"
+	curl --fail --silent --show-error \
+		-X PUT \
+		-H "Authorization: Bearer ${ACCESS_TOKEN}" \
+		-H "Accept: application/json" \
+		-H "Content-Type: application/json" \
+		--data-binary "@${json_file}" \
+		"$url"
+}
+
+api_delete() {
+	local url="$1"
+	curl --fail --silent --show-error \
+		-X DELETE \
+		-H "Authorization: Bearer ${ACCESS_TOKEN}" \
+		-H "Accept: application/json" \
+		"$url" >/dev/null || true
+}
+
+info "Creating Google Play edit for ${ANDROID_PACKAGE_NAME}."
+EDIT_ID="$(api_post "${API_ROOT}/edits" | jq -r '.id // empty')"
+[[ -n "$EDIT_ID" ]] || die "Google Play edit creation did not return an edit id."
+
+cleanup_edit() {
+	if [[ -n "${EDIT_ID:-}" && "${EDIT_COMMITTED:-0}" != "1" ]]; then
+		warn "Deleting uncommitted Google Play edit ${EDIT_ID}."
+		api_delete "${API_ROOT}/edits/${EDIT_ID}"
+	fi
+}
+trap cleanup_edit EXIT
+
+info "Uploading ${ANDROID_AAB_PATH} to Google Play edit ${EDIT_ID}."
+UPLOADED_VERSION_CODE="$(
+	curl --fail --silent --show-error \
+		-X POST \
+		-H "Authorization: Bearer ${ACCESS_TOKEN}" \
+		-H "Accept: application/json" \
+		-H "Content-Type: application/octet-stream" \
+		--data-binary "@${ANDROID_AAB_PATH}" \
+		"${UPLOAD_ROOT}/edits/${EDIT_ID}/bundles?uploadType=media" \
+		| jq -r '.versionCode // empty'
+)"
+
+[[ -n "$UPLOADED_VERSION_CODE" ]] || die "Google Play bundle upload did not return a versionCode."
+[[ "$UPLOADED_VERSION_CODE" == "$ANDROID_VERSION_CODE" ]] || die "Uploaded versionCode ${UPLOADED_VERSION_CODE} does not match $(app_version_file) androidVersionCode ${ANDROID_VERSION_CODE}."
+
+TRACK_PAYLOAD="$(mktemp "${RUNNER_TEMP:-/tmp}/tuindice-play-track.XXXXXX.json")"
+jq -n \
+	--arg track "$GOOGLE_PLAY_TRACK" \
+	--arg release_name "${VERSION_NAME} (${ANDROID_VERSION_CODE})" \
+	--arg version_code "$ANDROID_VERSION_CODE" \
+	'{
+		track: $track,
+		releases: [
+			{
+				name: $release_name,
+				versionCodes: [($version_code | tonumber)],
+				status: "draft"
+			}
+		]
+	}' >"$TRACK_PAYLOAD"
+
+info "Creating Google Play draft release on track ${GOOGLE_PLAY_TRACK}."
+api_put_json "${API_ROOT}/edits/${EDIT_ID}/tracks/${GOOGLE_PLAY_TRACK}" "$TRACK_PAYLOAD" >/dev/null
+
+info "Committing Google Play edit ${EDIT_ID}."
+api_post "${API_ROOT}/edits/${EDIT_ID}:commit" >/dev/null
+EDIT_COMMITTED=1
+info "Google Play draft release created for ${VERSION_NAME} (${ANDROID_VERSION_CODE})."

--- a/.github/scripts/validate-app-version.sh
+++ b/.github/scripts/validate-app-version.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+APP_BUILD_GRADLE="app/build.gradle"
+VERSION_NAME="$(get_app_version_name)"
+ANDROID_VERSION_CODE="$(get_android_version_code)"
+IOS_BUILD_NUMBER="$(get_ios_build_number)"
+
+validate_semver "$VERSION_NAME" || die "App versionName '${VERSION_NAME}' is invalid. Expected semantic version format X.Y.Z."
+validate_positive_integer "$ANDROID_VERSION_CODE" || die "androidVersionCode '${ANDROID_VERSION_CODE}' is invalid. Expected a positive integer."
+validate_positive_integer "$IOS_BUILD_NUMBER" || die "iosBuildNumber '${IOS_BUILD_NUMBER}' is invalid. Expected a positive integer."
+
+[[ -f "$APP_BUILD_GRADLE" ]] || die "Missing ${APP_BUILD_GRADLE}."
+
+grep -q 'rootProject.file("gradle/app-version.properties")' "$APP_BUILD_GRADLE" \
+	|| die "${APP_BUILD_GRADLE} must read version values from $(app_version_file)."
+grep -qE '^[[:space:]]*versionCode[[:space:]]+androidVersionCode[[:space:]]*$' "$APP_BUILD_GRADLE" \
+	|| die "${APP_BUILD_GRADLE} must use 'versionCode androidVersionCode'."
+grep -qE '^[[:space:]]*versionName[[:space:]]+appVersionName[[:space:]]*$' "$APP_BUILD_GRADLE" \
+	|| die "${APP_BUILD_GRADLE} must use 'versionName appVersionName'."
+
+if grep -qE '^[[:space:]]*versionCode[[:space:]]+[0-9]+[[:space:]]*$' "$APP_BUILD_GRADLE"; then
+	die "${APP_BUILD_GRADLE} still contains a hard-coded Android versionCode."
+fi
+
+if grep -qE '^[[:space:]]*versionName[[:space:]]+"[^"]+"[[:space:]]*$' "$APP_BUILD_GRADLE"; then
+	die "${APP_BUILD_GRADLE} still contains a hard-coded Android versionName."
+fi
+
+TAG_NAME="$(app_tag_name "$VERSION_NAME")"
+TAG_TARGET="$(existing_tag_target "$TAG_NAME" || true)"
+
+if [[ -n "$TAG_TARGET" && -n "${TARGET_GIT_SHA:-${GITHUB_SHA:-}}" ]]; then
+	TARGET_SHA="${TARGET_GIT_SHA:-${GITHUB_SHA:-}}"
+	if [[ "$TAG_TARGET" != "$TARGET_SHA" ]]; then
+		die "Tag ${TAG_NAME} already exists at ${TAG_TARGET}. Bump $(app_version_file) before deploying."
+	fi
+fi
+
+info "App version is valid: ${VERSION_NAME} androidVersionCode=${ANDROID_VERSION_CODE} iosBuildNumber=${IOS_BUILD_NUMBER} tag=${TAG_NAME}"

--- a/.github/scripts/validate-ci-config.sh
+++ b/.github/scripts/validate-ci-config.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+require_tool bash
+
+while IFS= read -r script_file; do
+	[[ -n "$script_file" ]] || continue
+	info "Checking shell syntax: ${script_file}"
+	bash -n "$script_file"
+done < <(
+	find .github/scripts e2e/scripts iosApp/scripts -name '*.sh' -type f 2>/dev/null | sort
+)
+
+while IFS= read -r workflow_file; do
+	[[ -n "$workflow_file" ]] || continue
+	info "Found workflow: ${workflow_file}"
+done < <(
+	find .github/workflows \( -name '*.yml' -o -name '*.yaml' \) -type f 2>/dev/null | sort
+)
+
+info "CI configuration syntax checks passed."

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,72 @@
+name: Deploy production
+
+on:
+  push:
+    branches:
+      - production
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+env:
+  GCP_PROJECT: tu-indice-usb
+  ANDROID_PACKAGE_NAME: com.gdavidpb.tuindice
+  GOOGLE_PLAY_TRACK: production
+
+jobs:
+  deploy:
+    name: Deploy Android production draft
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 75
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+
+      - name: Configure git identity for release tags
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Authenticate to Google Cloud for Play publishing
+        id: google-auth
+        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PLAY_PUBLISHER_SERVICE_ACCOUNT }}
+          project_id: ${{ env.GCP_PROJECT }}
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/androidpublisher
+
+      - name: Deploy Android production draft
+        env:
+          TARGET_GIT_SHA: ${{ github.sha }}
+          ANDROID_PUBLISHER_ACCESS_TOKEN: ${{ steps.google-auth.outputs.access_token }}
+          ANDROID_GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_BASE64 }}
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+          TU_INDICE_KEY_ALIAS: ${{ secrets.TU_INDICE_KEY_ALIAS }}
+          TU_INDICE_KEY_PASSWORD: ${{ secrets.TU_INDICE_KEY_PASSWORD }}
+          TU_INDICE_KEY_STORE_PASSWORD: ${{ secrets.TU_INDICE_KEY_STORE_PASSWORD }}
+          TUINDICE_UPLOAD_CRASHLYTICS_MAPPING: "1"
+        run: |
+          set -euo pipefail
+          bash ./.github/scripts/deploy-production.sh

--- a/.github/workflows/preflight-production-pr.yml
+++ b/.github/workflows/preflight-production-pr.yml
@@ -1,0 +1,118 @@
+name: Preflight production PR
+
+on:
+  pull_request:
+    branches:
+      - production
+
+concurrency:
+  group: preflight-production-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: Android release preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Detect changed app pieces
+        id: changes
+        run: |
+          set -euo pipefail
+          merge_base="$(git merge-base "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+          echo "Using merge base ${merge_base} for PR preflight diff."
+          STATE_DIR="${RUNNER_TEMP}/tuindice-changes" \
+            bash ./.github/scripts/detect-changed-app.sh "$merge_base" "${{ github.event.pull_request.head.sha }}"
+
+      - name: Validate CI/CD configuration
+        if: steps.changes.outputs.ci_config_touched == 'true'
+        run: |
+          set -euo pipefail
+          bash ./.github/scripts/validate-ci-config.sh
+
+      - name: Skip preflight when there are no relevant changes
+        if: steps.changes.outputs.has_relevant_changes != 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## Production preflight summary"
+            echo
+            echo "- No deployable app changes were detected."
+            echo "- Workflow finished successfully without validations."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Set up Java
+        if: steps.changes.outputs.android_tasks != ''
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        if: steps.changes.outputs.android_tasks != ''
+        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+
+      - name: Materialize Firebase configuration
+        if: contains(steps.changes.outputs.android_tasks, ':app:bundleRelease')
+        env:
+          ANDROID_GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_BASE64 }}
+        run: |
+          set -euo pipefail
+          REQUIRE_FIREBASE_CONFIGS=1 bash ./.github/scripts/materialize-firebase-configs.sh
+
+      - name: Materialize Android release signing
+        if: contains(steps.changes.outputs.android_tasks, ':app:bundleRelease')
+        env:
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+          TU_INDICE_KEY_ALIAS: ${{ secrets.TU_INDICE_KEY_ALIAS }}
+          TU_INDICE_KEY_PASSWORD: ${{ secrets.TU_INDICE_KEY_PASSWORD }}
+          TU_INDICE_KEY_STORE_PASSWORD: ${{ secrets.TU_INDICE_KEY_STORE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          bash ./.github/scripts/materialize-android-signing.sh
+
+      - name: Run release preflight checks
+        if: steps.changes.outputs.has_relevant_changes == 'true'
+        env:
+          TARGET_GIT_SHA: ${{ github.event.pull_request.head.sha }}
+          MISSING_VERSION_BUMP_FILE: ${{ steps.changes.outputs.missing_version_bump_file }}
+          HAS_RELEVANT_CHANGES: ${{ steps.changes.outputs.has_relevant_changes }}
+        run: |
+          set -euo pipefail
+          bash ./.github/scripts/preflight-production.sh
+
+      - name: Run focused Android checks
+        if: steps.changes.outputs.android_tasks != ''
+        env:
+          TU_INDICE_KEY_ALIAS: ${{ secrets.TU_INDICE_KEY_ALIAS }}
+          TU_INDICE_KEY_PASSWORD: ${{ secrets.TU_INDICE_KEY_PASSWORD }}
+          TU_INDICE_KEY_STORE_PASSWORD: ${{ secrets.TU_INDICE_KEY_STORE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          ./gradlew --continue --console=plain --max-workers=2 ${{ steps.changes.outputs.android_tasks }}
+
+  preflight-production-pr:
+    name: preflight-production-pr
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+    if: always()
+    steps:
+      - name: Verify preflight jobs
+        run: |
+          set -euo pipefail
+          preflight_result="${{ needs.preflight.result }}"
+          echo "Preflight result: ${preflight_result}"
+          if [[ "${preflight_result}" != "success" ]]; then
+            exit 1
+          fi

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,23 @@ apply plugin: "kotlin-kapt"
 apply plugin: "com.google.gms.google-services"
 apply plugin: "com.google.firebase.crashlytics"
 
+def appVersionPropertiesFile = rootProject.file("gradle/app-version.properties")
+def appVersionProperties = new Properties()
+if (!appVersionPropertiesFile.isFile()) {
+    throw new GradleException("Missing ${appVersionPropertiesFile}.")
+}
+appVersionPropertiesFile.withInputStream { appVersionProperties.load(it) }
+
+def appVersionName = appVersionProperties.getProperty("versionName")?.trim()
+def androidVersionCodeValue = appVersionProperties.getProperty("androidVersionCode")?.trim()
+if (!appVersionName) {
+    throw new GradleException("Missing versionName in ${appVersionPropertiesFile}.")
+}
+if (!(androidVersionCodeValue ==~ /[1-9][0-9]*/)) {
+    throw new GradleException("androidVersionCode in ${appVersionPropertiesFile} must be a positive integer.")
+}
+def androidVersionCode = androidVersionCodeValue.toInteger()
+
 android {
     namespace "com.gdavidpb.tuindice"
 
@@ -16,8 +33,8 @@ android {
         vectorDrawables.useSupportLibrary = true
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 37
-        versionName "5.9.1"
+        versionCode androidVersionCode
+        versionName appVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -27,9 +44,12 @@ android {
 
     signingConfigs {
         release {
+            def tuIndiceKeyStorePath = System.getenv("TU_INDICE_KEY_STORE_PATH")
             keyAlias System.getenv("TU_INDICE_KEY_ALIAS")
             keyPassword System.getenv("TU_INDICE_KEY_PASSWORD")
-            storeFile file("${System.getenv("TU_INDICE_KEY_STORE_PATH")}")
+            if (tuIndiceKeyStorePath) {
+                storeFile file(tuIndiceKeyStorePath)
+            }
             storePassword System.getenv("TU_INDICE_KEY_STORE_PASSWORD")
         }
     }
@@ -72,6 +92,10 @@ android {
             minifyEnabled true
 
             signingConfig signingConfigs.release
+
+            firebaseCrashlytics {
+                mappingFileUploadEnabled System.getenv("TUINDICE_UPLOAD_CRASHLYTICS_MAPPING") == "1"
+            }
 
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
 

--- a/app/src/test/java/com/gdavidpb/tuindice/ComputationTest.kt
+++ b/app/src/test/java/com/gdavidpb/tuindice/ComputationTest.kt
@@ -204,6 +204,7 @@ class ComputationTest {
             subjects: MutableList<Subject> = mutableListOf()
     ) = Quarter(
             id = "",
+            name = "",
             startDate = startDate,
             endDate = endDate,
             grade = 0.0,

--- a/build.gradle
+++ b/build.gradle
@@ -39,3 +39,9 @@ allprojects {
 tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }
+
+tasks.register("verifyAppVersionSync", Exec) {
+    group = "verification"
+    description = "Validates that Android release metadata reads from gradle/app-version.properties."
+    commandLine "bash", "${rootDir}/.github/scripts/validate-app-version.sh"
+}

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -1,0 +1,104 @@
+# Pipeline de release
+
+Este branch de `production` contiene la app Android legacy. El flujo replica el backend con ramas `feat/*`, PR obligatorio hacia `production`, preflight obligatorio y deploy automatico solo cuando el merge llega a `production`.
+
+## Alcance actual
+
+- Preflight en PR hacia `production`: valida version, detecta cambios relevantes y ejecuta solo tareas Android necesarias.
+- Deploy en push a `production`: construye un AAB firmado, publica un draft en Google Play track `production` y crea el tag anotado `app-<versionName>`.
+- Firebase Test Lab y E2E locales quedan fuera de este branch legacy.
+- App Store Connect ya puede tener secretos cargados, pero el upload iOS queda diferido hasta que `iosApp` exista en `production`.
+
+## Version unica
+
+La fuente de version vive en `gradle/app-version.properties`:
+
+```properties
+versionName=6.0.0
+androidVersionCode=39
+iosBuildNumber=25
+```
+
+Android lee `versionName` y `androidVersionCode` desde `app/build.gradle`. `iosBuildNumber` queda reservado para mantener la misma fuente cuando entre la app iOS.
+
+Valida localmente con:
+
+```bash
+./gradlew verifyAppVersionSync
+```
+
+Para cambios runtime o release se debe subir al menos `versionName` y `androidVersionCode`. El deploy falla si `app-<versionName>` ya existe apuntando a otro SHA.
+
+## Preflight
+
+El detector compara el PR contra el merge-base de `production`.
+
+- Cambios en docs no disparan tests ni release.
+- Cambios solo en tests ejecutan `:app:testDebugUnitTest`.
+- Cambios en app runtime, Gradle, version o CI ejecutan la bateria enfocada de Android.
+- Cambios release ejecutan `:app:testDebugUnitTest`, `:app:bundleRelease` y exigen bump de version.
+- Cambios de CI ejecutan tambien `verifyAppVersionSync`.
+
+Validacion local del detector:
+
+```bash
+merge_base="$(git merge-base production HEAD)"
+STATE_DIR=/tmp/tuindice-changes bash ./.github/scripts/detect-changed-app.sh "$merge_base" HEAD
+```
+
+## Deploy
+
+El deploy corre en `ubuntu-latest` bajo el environment `production`.
+
+1. Revalida version, tag y bump requerido.
+2. Materializa `app/google-services.json` desde `ANDROID_GOOGLE_SERVICES_JSON_BASE64`.
+3. Materializa el keystore release desde `ANDROID_RELEASE_KEYSTORE_BASE64`.
+4. Construye `:app:bundleRelease`.
+5. Sube mapping de Crashlytics solo en deploy con `TUINDICE_UPLOAD_CRASHLYTICS_MAPPING=1`.
+6. Crea un edit en Google Play, sube el AAB y deja un draft en el track `production`.
+7. Crea y pushea el tag anotado `app-<versionName>` solo despues del draft.
+
+Dry-run local:
+
+```bash
+DRY_RUN=1 bash ./.github/scripts/deploy-production.sh
+```
+
+## Branch protection
+
+`production` debe tener:
+
+- Require a pull request before merging.
+- Block direct pushes.
+- Require status checks before merging.
+- Required check: `preflight-production-pr`.
+- Environment `production` para el deploy.
+
+## Secrets requeridos ahora
+
+```text
+GCP_WORKLOAD_IDENTITY_PROVIDER
+GCP_PLAY_PUBLISHER_SERVICE_ACCOUNT
+ANDROID_GOOGLE_SERVICES_JSON_BASE64
+ANDROID_RELEASE_KEYSTORE_BASE64
+TU_INDICE_KEY_ALIAS
+TU_INDICE_KEY_PASSWORD
+TU_INDICE_KEY_STORE_PASSWORD
+```
+
+La service account debe tener permisos de Android Publisher sobre `com.gdavidpb.tuindice`.
+
+## Secrets preparados para iOS futuro
+
+Estos secretos no son usados por este branch legacy, pero quedan listos para el branch donde `iosApp` llegue a `production`:
+
+```text
+IOS_GOOGLE_SERVICE_INFO_PLIST_BASE64
+APP_STORE_CONNECT_KEY_ID
+APP_STORE_CONNECT_ISSUER_ID
+APP_STORE_CONNECT_API_KEY_P8_BASE64
+APPLE_TEAM_ID
+APPLE_DISTRIBUTION_CERTIFICATE_P12_BASE64
+APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD
+APPLE_PROVISIONING_PROFILE_BASE64
+```

--- a/gradle/app-version.properties
+++ b/gradle/app-version.properties
@@ -1,0 +1,3 @@
+versionName=6.0.0
+androidVersionCode=39
+iosBuildNumber=25


### PR DESCRIPTION
## Summary

- Adds the production PR preflight and production deploy workflows for the current Android legacy branch.
- Introduces `gradle/app-version.properties` as the single version source, starting at `versionName=6.0.0` and `androidVersionCode=39`.
- Publishes Android drafts to Google Play production track on `push` to `production`, then creates the annotated `app-<versionName>` tag after the draft succeeds.
- Documents that App Store Connect upload is deferred until `iosApp` exists in `production`.

## Validation

- `bash ./.github/scripts/validate-ci-config.sh`
- `bash ./.github/scripts/validate-app-version.sh`
- `./gradlew --console=plain verifyAppVersionSync`
- `TU_INDICE_KEY_STORE_PATH=... ./gradlew --continue --console=plain --max-workers=2 verifyAppVersionSync :app:testDebugUnitTest :app:bundleRelease`
- `DEPLOY_DIFF_BASE_SHA=production DRY_RUN=1 TU_INDICE_KEY_STORE_PATH=... bash ./.github/scripts/deploy-production.sh`
- Dry-run merge of `feat/release-pipeline` into `production` completed without conflicts.