### PR TITLE
Fix production deploy signing

### DIFF
--- a/.github/scripts/detect-changed-app.sh
+++ b/.github/scripts/detect-changed-app.sh
@@ -341,6 +341,11 @@ classify_changed_file() {
 			append_e2e_scope all local-certification-suite "root-build"
 			return 0
 			;;
+		iosApp/scripts/*)
+			CI_CONFIG_TOUCHED=true
+			HAS_RELEVANT_CHANGES=true
+			return 0
+			;;
 		iosApp/*)
 			if is_ios_app_test_source_file "$file"; then
 				append_changed_test_module iosApp

--- a/.github/scripts/publish-google-play-draft.sh
+++ b/.github/scripts/publish-google-play-draft.sh
@@ -30,6 +30,31 @@ api_post() {
 		"$url"
 }
 
+api_get_json() {
+	local url="$1"
+	local output_file="$2"
+	local status_code
+
+	status_code="$(
+		curl --silent --show-error \
+			-X GET \
+			-H "Authorization: Bearer ${ACCESS_TOKEN}" \
+			-H "Accept: application/json" \
+			-o "$output_file" \
+			-w '%{http_code}' \
+			"$url"
+	)"
+
+	if [[ "$status_code" == "404" ]]; then
+		return 1
+	fi
+
+	if [[ ! "$status_code" =~ ^2 ]]; then
+		cat "$output_file" >&2 || true
+		die "Google Play API GET failed with HTTP ${status_code}: ${url}"
+	fi
+}
+
 api_put_json() {
 	local url="$1"
 	local json_file="$2"
@@ -62,6 +87,26 @@ cleanup_edit() {
 	fi
 }
 trap cleanup_edit EXIT
+
+TRACK_STATE="$(mktemp "${RUNNER_TEMP:-/tmp}/tuindice-play-track-state.XXXXXX.json")"
+if api_get_json "${API_ROOT}/edits/${EDIT_ID}/tracks/${GOOGLE_PLAY_TRACK}" "$TRACK_STATE"; then
+	EXISTING_RELEASE_STATUS="$(
+		jq -r \
+			--arg version_code "$ANDROID_VERSION_CODE" \
+			'[
+				.releases[]?
+				| select(any(.versionCodes[]?; tostring == $version_code))
+				| (.status // "unknown")
+			][0] // empty' \
+			"$TRACK_STATE"
+	)"
+	if [[ -n "$EXISTING_RELEASE_STATUS" ]]; then
+		info "Google Play release for ${VERSION_NAME} (${ANDROID_VERSION_CODE}) already exists on track ${GOOGLE_PLAY_TRACK} with status ${EXISTING_RELEASE_STATUS}; skipping bundle upload."
+		exit 0
+	fi
+else
+	info "Google Play track ${GOOGLE_PLAY_TRACK} does not exist in edit ${EDIT_ID}; continuing with first draft upload."
+fi
 
 info "Uploading ${ANDROID_AAB_PATH} to Google Play edit ${EDIT_ID}."
 UPLOADED_VERSION_CODE="$(

--- a/.github/scripts/test-detect-changed-app.sh
+++ b/.github/scripts/test-detect-changed-app.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+require_tool() {
+	command -v "$1" >/dev/null 2>&1 || {
+		printf 'Required tool %s is not available.\n' "$1" >&2
+		exit 1
+	}
+}
+
+require_tool git
+
+HEAD_SHA="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+
+assert_file_empty() {
+	local file="$1"
+	local label="$2"
+
+	if [[ -s "$file" ]]; then
+		printf 'Expected %s to be empty, got:\n' "$label" >&2
+		cat "$file" >&2
+		exit 1
+	fi
+}
+
+assert_file_contains_line() {
+	local file="$1"
+	local expected="$2"
+	local label="$3"
+
+	if ! grep -Fxq "$expected" "$file"; then
+		printf 'Expected %s to contain "%s", got:\n' "$label" "$expected" >&2
+		cat "$file" >&2 || true
+		exit 1
+	fi
+}
+
+run_detector_fixture() {
+	local name="$1"
+	local changed_path="$2"
+	local temp_dir
+	local changed_files_file
+	local output_file
+
+	temp_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/tuindice-detect-test.XXXXXX")"
+	changed_files_file="${temp_dir}/changed-files.txt"
+	output_file="${temp_dir}/output.log"
+	printf '%s\n' "$changed_path" >"$changed_files_file"
+
+	(
+		cd "${REPO_ROOT}"
+		STATE_DIR="${temp_dir}/state" \
+		DETECT_CHANGED_APP_CHANGED_FILES_FILE="$changed_files_file" \
+			bash ./.github/scripts/detect-changed-app.sh "$HEAD_SHA" "$HEAD_SHA"
+	) >"$output_file" 2>&1
+
+	case "$name" in
+		ios-script-tooling)
+			assert_file_empty "${temp_dir}/state/impacted-modules.txt" "impacted modules"
+			assert_file_empty "${temp_dir}/state/release-impacted-modules.txt" "release impacted modules"
+			assert_file_empty "${temp_dir}/state/missing-version-bump.txt" "missing version bump"
+			assert_file_empty "${temp_dir}/state/e2e-suites.txt" "E2E suites"
+			assert_file_empty "${temp_dir}/state/e2e-scope.csv" "E2E scope"
+			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" "verifyAppVersionSync" "Android tasks"
+			assert_file_empty "${temp_dir}/state/ios-gradle-tasks.txt" "iOS tasks"
+			;;
+		ios-host-runtime)
+			assert_file_contains_line "${temp_dir}/state/impacted-modules.txt" "iosApp" "impacted modules"
+			assert_file_contains_line "${temp_dir}/state/release-impacted-modules.txt" "iosApp" "release impacted modules"
+			assert_file_contains_line "${temp_dir}/state/missing-version-bump.txt" "app" "missing version bump"
+			assert_file_contains_line "${temp_dir}/state/e2e-scope.csv" "ios,local-certification-suite,ios-host-runtime" "E2E scope"
+			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildRelease" "iOS tasks"
+			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
+			;;
+		*)
+			printf 'Unknown detector fixture: %s\n' "$name" >&2
+			exit 1
+			;;
+	esac
+}
+
+run_detector_fixture ios-script-tooling iosApp/scripts/ci-upload-ios-appstore.sh
+run_detector_fixture ios-host-runtime iosApp/Sources/TuIndiceHost/TuIndiceAppBootstrap.swift
+
+printf 'Detect changed app shell fixtures passed.\n'

--- a/.github/scripts/validate-ci-config.sh
+++ b/.github/scripts/validate-ci-config.sh
@@ -24,5 +24,6 @@ done < <(
 )
 
 bash "${SCRIPT_DIR}/test-preflight-production.sh"
+bash "${SCRIPT_DIR}/test-detect-changed-app.sh"
 
 info "CI configuration syntax checks passed."

--- a/iosApp/scripts/ci-upload-ios-appstore.sh
+++ b/iosApp/scripts/ci-upload-ios-appstore.sh
@@ -14,6 +14,11 @@ API_KEY_PATH="${APP_STORE_CONNECT_API_KEY_PATH:-}"
 API_KEY_ID="${APP_STORE_CONNECT_KEY_ID:-}"
 API_ISSUER_ID="${APP_STORE_CONNECT_ISSUER_ID:-}"
 APPLE_TEAM_ID_VALUE="${APPLE_TEAM_ID:-94BBJ5X5GL}"
+IOS_BUNDLE_IDENTIFIER="${IOS_BUNDLE_IDENTIFIER:-com.gdavidpb.tuindice}"
+CODE_SIGN_STYLE_VALUE="${IOS_CODE_SIGN_STYLE:-Manual}"
+CODE_SIGN_IDENTITY_VALUE="${IOS_CODE_SIGN_IDENTITY:-Apple Distribution}"
+PROFILE_SPECIFIER="${APPLE_PROVISIONING_PROFILE_SPECIFIER:-}"
+PROFILE_UUID="${APPLE_PROVISIONING_PROFILE_UUID:-}"
 KEYCHAIN_PATH="${APPLE_KEYCHAIN_PATH:-${RUNNER_TEMP:-/tmp}/tuindice-signing.keychain-db}"
 KEYCHAIN_PASSWORD="${APPLE_KEYCHAIN_PASSWORD:-tuindice-ci-keychain}"
 
@@ -38,6 +43,24 @@ decode_base64_to_file() {
 	fi
 }
 
+plist_value() {
+	local plist_file="$1"
+	local key="$2"
+
+	/usr/libexec/PlistBuddy -c "Print :${key}" "$plist_file" 2>/dev/null || true
+}
+
+xml_escape() {
+	local value="$1"
+
+	value="${value//&/&amp;}"
+	value="${value//</&lt;}"
+	value="${value//>/&gt;}"
+	value="${value//\"/&quot;}"
+	value="${value//\'/&apos;}"
+	printf '%s' "$value"
+}
+
 if [[ "$OSTYPE" != darwin* ]]; then
 	die "App Store Connect upload requires macOS."
 fi
@@ -51,6 +74,12 @@ fi
 [[ -n "$API_KEY_ID" ]] || die "APP_STORE_CONNECT_KEY_ID is required."
 [[ -n "$API_ISSUER_ID" ]] || die "APP_STORE_CONNECT_ISSUER_ID is required."
 
+if [[ "$CODE_SIGN_STYLE_VALUE" == "Manual" ]]; then
+	[[ -n "${APPLE_DISTRIBUTION_CERTIFICATE_P12_BASE64:-}" ]] || die "APPLE_DISTRIBUTION_CERTIFICATE_P12_BASE64 is required for manual iOS signing."
+	[[ -n "${APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD:-}" ]] || die "APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD is required for manual iOS signing."
+	[[ -n "${APPLE_PROVISIONING_PROFILE_BASE64:-}" || -n "$PROFILE_SPECIFIER" || -n "$PROFILE_UUID" ]] || die "APPLE_PROVISIONING_PROFILE_BASE64, APPLE_PROVISIONING_PROFILE_SPECIFIER, or APPLE_PROVISIONING_PROFILE_UUID is required for manual iOS signing."
+fi
+
 if [[ -n "${APPLE_DISTRIBUTION_CERTIFICATE_P12_BASE64:-}" ]]; then
 	CERTIFICATE_PATH="${RUNNER_TEMP:-/tmp}/tuindice-distribution.p12"
 	decode_base64_to_file "$APPLE_DISTRIBUTION_CERTIFICATE_P12_BASE64" "$CERTIFICATE_PATH"
@@ -63,17 +92,40 @@ if [[ -n "${APPLE_DISTRIBUTION_CERTIFICATE_P12_BASE64:-}" ]]; then
 	security import "$CERTIFICATE_PATH" \
 		-P "$APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD" \
 		-A \
-		-t cert \
 		-f pkcs12 \
 		-k "$KEYCHAIN_PATH"
 	security list-keychain -d user -s "$KEYCHAIN_PATH"
+	security default-keychain -d user -s "$KEYCHAIN_PATH"
 	security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+	if [[ "$CODE_SIGN_STYLE_VALUE" == "Manual" ]]; then
+		security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+		security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -q "$CODE_SIGN_IDENTITY_VALUE" ||
+			die "No ${CODE_SIGN_IDENTITY_VALUE} signing identity with private key was imported."
+	fi
 fi
 
 if [[ -n "${APPLE_PROVISIONING_PROFILE_BASE64:-}" ]]; then
 	PROFILE_DIR="${HOME}/Library/MobileDevice/Provisioning Profiles"
+	PROFILE_SOURCE_PATH="${RUNNER_TEMP:-/tmp}/tuindice.mobileprovision"
+	PROFILE_PLIST_PATH="${RUNNER_TEMP:-/tmp}/tuindice.mobileprovision.plist"
 	mkdir -p "$PROFILE_DIR"
-	decode_base64_to_file "$APPLE_PROVISIONING_PROFILE_BASE64" "${PROFILE_DIR}/tuindice.mobileprovision"
+	decode_base64_to_file "$APPLE_PROVISIONING_PROFILE_BASE64" "$PROFILE_SOURCE_PATH"
+	security cms -D -i "$PROFILE_SOURCE_PATH" >"$PROFILE_PLIST_PATH"
+
+	if [[ -z "$PROFILE_UUID" ]]; then
+		PROFILE_UUID="$(plist_value "$PROFILE_PLIST_PATH" UUID)"
+	fi
+	if [[ -z "$PROFILE_SPECIFIER" ]]; then
+		PROFILE_SPECIFIER="$(plist_value "$PROFILE_PLIST_PATH" Name)"
+	fi
+
+	[[ -n "$PROFILE_UUID" ]] || die "Unable to resolve provisioning profile UUID."
+	cp "$PROFILE_SOURCE_PATH" "${PROFILE_DIR}/${PROFILE_UUID}.mobileprovision"
+fi
+
+if [[ "$CODE_SIGN_STYLE_VALUE" == "Manual" ]]; then
+	[[ -n "$PROFILE_SPECIFIER" || -n "$PROFILE_UUID" ]] || die "Unable to resolve manual provisioning profile specifier."
 fi
 
 bash "$REPO_ROOT/.github/scripts/sync-app-version.sh"
@@ -98,6 +150,30 @@ declare -a auth_args=(
 	-authenticationKeyIssuerID "$API_ISSUER_ID"
 )
 
+declare -a archive_signing_args=(
+	DEVELOPMENT_TEAM="$APPLE_TEAM_ID_VALUE"
+	CODE_SIGN_STYLE="$CODE_SIGN_STYLE_VALUE"
+)
+
+if [[ "$CODE_SIGN_STYLE_VALUE" == "Manual" ]]; then
+	archive_signing_args+=(
+		CODE_SIGN_IDENTITY="$CODE_SIGN_IDENTITY_VALUE"
+	)
+	if [[ -n "$PROFILE_SPECIFIER" ]]; then
+		archive_signing_args+=(
+			PROVISIONING_PROFILE_SPECIFIER="$PROFILE_SPECIFIER"
+		)
+	else
+		archive_signing_args+=(
+			PROVISIONING_PROFILE="$PROFILE_UUID"
+		)
+	fi
+else
+	archive_signing_args+=(
+		"${auth_args[@]}"
+	)
+fi
+
 mkdir -p "$(dirname "$ARCHIVE_PATH")" "$EXPORT_PATH"
 
 log "Archiving ${SCHEME_NAME} for App Store Connect."
@@ -108,13 +184,22 @@ xcodebuild \
 	-sdk iphoneos \
 	-destination "generic/platform=iOS" \
 	-archivePath "$ARCHIVE_PATH" \
-	DEVELOPMENT_TEAM="$APPLE_TEAM_ID_VALUE" \
-	CODE_SIGN_STYLE=Automatic \
-	"${auth_args[@]}" \
+	"${archive_signing_args[@]}" \
 	archive
 
 EXPORT_OPTIONS_PLIST="${RUNNER_TEMP:-/tmp}/tuindice-export-options.plist"
-cat >"$EXPORT_OPTIONS_PLIST" <<EOF
+if [[ "$CODE_SIGN_STYLE_VALUE" == "Manual" ]]; then
+	PROFILE_EXPORT_VALUE="$(xml_escape "${PROFILE_SPECIFIER:-$PROFILE_UUID}")"
+	BUNDLE_IDENTIFIER_VALUE="$(xml_escape "$IOS_BUNDLE_IDENTIFIER")"
+	SIGNING_STYLE_EXPORT="manual"
+else
+	PROFILE_EXPORT_VALUE=""
+	BUNDLE_IDENTIFIER_VALUE=""
+	SIGNING_STYLE_EXPORT="automatic"
+fi
+
+{
+cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -126,7 +211,20 @@ cat >"$EXPORT_OPTIONS_PLIST" <<EOF
 	<key>method</key>
 	<string>app-store-connect</string>
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>${SIGNING_STYLE_EXPORT}</string>
+EOF
+
+if [[ "$CODE_SIGN_STYLE_VALUE" == "Manual" ]]; then
+cat <<EOF
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>${BUNDLE_IDENTIFIER_VALUE}</key>
+		<string>${PROFILE_EXPORT_VALUE}</string>
+	</dict>
+EOF
+fi
+
+cat <<EOF
 	<key>stripSwiftSymbols</key>
 	<true/>
 	<key>teamID</key>
@@ -136,6 +234,7 @@ cat >"$EXPORT_OPTIONS_PLIST" <<EOF
 </dict>
 </plist>
 EOF
+} >"$EXPORT_OPTIONS_PLIST"
 
 log "Uploading archive to App Store Connect."
 xcodebuild \


### PR DESCRIPTION
## Summary
- Make Google Play draft publishing idempotent when the versionCode already exists on the target track.
- Switch iOS App Store archiving to manual signing with the imported Apple Distribution identity and provisioning profile.
- Generate manual export options for App Store Connect upload.

## Root Cause
The production deploy reached Google Play and created the Android draft, then failed during iOS archive because Xcode automatic signing requested an iOS Development certificate on the CI runner.

## Validation
- bash -n .github/scripts/publish-google-play-draft.sh
- bash -n iosApp/scripts/ci-upload-ios-appstore.sh
- git diff --check