### PR TITLE
Fix iOS production deploy

### DIFF
--- a/.github/scripts/detect-changed-app.sh
+++ b/.github/scripts/detect-changed-app.sh
@@ -36,6 +36,7 @@ mkdir -p "$STATE_DIR"
 APP_VERSION_TOUCHED=false
 APP_VERSION_CHANGED=false
 CI_CONFIG_TOUCHED=false
+IOS_CI_SCRIPTS_TOUCHED=false
 E2E_CONTRACT_TOUCHED=false
 HAS_RELEVANT_CHANGES=false
 HAS_RELEASE_IMPACT=false
@@ -395,6 +396,7 @@ classify_changed_file() {
 			;;
 		iosApp/scripts/*)
 			CI_CONFIG_TOUCHED=true
+			IOS_CI_SCRIPTS_TOUCHED=true
 			HAS_RELEVANT_CHANGES=true
 			return 0
 			;;
@@ -567,6 +569,7 @@ info "App version touched: ${APP_VERSION_TOUCHED}"
 info "App version changed: ${APP_VERSION_CHANGED}"
 info "Missing version bump: $(file_to_csv "$MISSING_VERSION_BUMP_FILE" || true)"
 info "CI/CD configuration touched: ${CI_CONFIG_TOUCHED}"
+info "iOS CI scripts touched: ${IOS_CI_SCRIPTS_TOUCHED}"
 info "E2E suites requiring local certification: $(file_to_csv "$E2E_SUITES_FILE" || true)"
 info "E2E scope: $(file_to_csv "$E2E_SCOPE_FILE" || true)"
 info "E2E Android contexts: $(file_to_csv "$E2E_ANDROID_CONTEXTS_FILE" || true)"
@@ -591,6 +594,7 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
 		printf 'app_version_touched=%s\n' "$APP_VERSION_TOUCHED"
 		printf 'app_version_changed=%s\n' "$APP_VERSION_CHANGED"
 		printf 'ci_config_touched=%s\n' "$CI_CONFIG_TOUCHED"
+		printf 'ios_ci_scripts_touched=%s\n' "$IOS_CI_SCRIPTS_TOUCHED"
 		printf 'e2e_contract_touched=%s\n' "$E2E_CONTRACT_TOUCHED"
 		printf 'requires_e2e_certification=%s\n' "$REQUIRES_E2E_CERTIFICATION"
 		printf 'e2e_suites_file=%s\n' "$E2E_SUITES_FILE"

--- a/.github/scripts/publish-google-play-draft.sh
+++ b/.github/scripts/publish-google-play-draft.sh
@@ -114,7 +114,7 @@ cleanup_edit() {
 }
 trap cleanup_edit EXIT
 
-TRACK_STATE="$(mktemp "${RUNNER_TEMP:-/tmp}/tuindice-play-track-state.XXXXXX.json")"
+TRACK_STATE="$(mktemp "${RUNNER_TEMP:-/tmp}/tuindice-play-track-state.XXXXXX")"
 if api_get_json "${API_ROOT}/edits/${EDIT_ID}/tracks/${GOOGLE_PLAY_TRACK}" "$TRACK_STATE"; then
 	EXISTING_RELEASE_STATUS="$(
 		jq -r \
@@ -159,7 +159,7 @@ UPLOADED_VERSION_CODE="$(
 [[ -n "$UPLOADED_VERSION_CODE" ]] || die "Google Play bundle upload did not return a versionCode."
 [[ "$UPLOADED_VERSION_CODE" == "$ANDROID_VERSION_CODE" ]] || die "Uploaded versionCode ${UPLOADED_VERSION_CODE} does not match $(app_version_file) androidVersionCode ${ANDROID_VERSION_CODE}."
 
-TRACK_PAYLOAD="$(mktemp "${RUNNER_TEMP:-/tmp}/tuindice-play-track.XXXXXX.json")"
+TRACK_PAYLOAD="$(mktemp "${RUNNER_TEMP:-/tmp}/tuindice-play-track.XXXXXX")"
 jq -n \
 	--arg track "$GOOGLE_PLAY_TRACK" \
 	--arg release_name "${VERSION_NAME} (${ANDROID_VERSION_CODE})" \

--- a/.github/scripts/test-appstore-connect-check.sh
+++ b/.github/scripts/test-appstore-connect-check.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=.github/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+require_tool jq
+require_tool ruby
+
+VERSION_NAME="$(get_app_version_name)"
+IOS_BUILD_NUMBER="$(get_ios_build_number)"
+
+assert_file_contains_line() {
+	local file="$1"
+	local expected="$2"
+	local label="$3"
+
+	if ! grep -Fxq "$expected" "$file"; then
+		printf 'Expected %s to contain "%s", got:\n' "$label" "$expected" >&2
+		cat "$file" >&2 || true
+		exit 1
+	fi
+}
+
+run_appstore_check_fixture() {
+	local name="$1"
+	local expected_exists="$2"
+	local expected_build_id="$3"
+	local temp_dir
+	local bin_dir
+	local api_key_path
+	local github_output
+	local exists_file
+
+	temp_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/tuindice-appstore-check-test.XXXXXX")"
+	bin_dir="${temp_dir}/bin"
+	api_key_path="${temp_dir}/AuthKey_TESTKEYID1.p8"
+	github_output="${temp_dir}/github-output.txt"
+	exists_file="${temp_dir}/ios-build-exists.env"
+	mkdir -p "$bin_dir"
+
+	ruby -ropenssl -e 'puts OpenSSL::PKey::EC.generate("prime256v1").to_pem' >"$api_key_path"
+
+	cat >"${bin_dir}/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${TUINDICE_APPSTORE_TEST_MODE:?}"
+version_name="${TUINDICE_APPSTORE_TEST_VERSION_NAME:?}"
+method="GET"
+output_file=""
+url=""
+
+while [[ "$#" -gt 0 ]]; do
+	case "$1" in
+		-X)
+			method="$2"
+			shift 2
+			;;
+		-H|-o|-w)
+			if [[ "$1" == "-o" ]]; then
+				output_file="$2"
+			fi
+			shift 2
+			;;
+		--silent|--show-error|--fail)
+			shift
+			;;
+		*)
+			url="$1"
+			shift
+			;;
+	esac
+done
+
+if [[ "$method" != "GET" ]]; then
+	printf 'Unexpected method: %s\n' "$method" >&2
+	exit 1
+fi
+
+[[ -n "$output_file" ]] || {
+	printf 'Expected curl -o output file.\n' >&2
+	exit 1
+}
+
+case "$url" in
+	*/apps\?*)
+		printf '{"data":[{"id":"app-1"}]}\n' >"$output_file"
+		;;
+	*/builds\?*)
+		if [[ "$mode" == "exists" ]]; then
+			jq -n --arg version_name "$version_name" '{
+				data: [
+					{
+						id: "build-1",
+						relationships: {
+							preReleaseVersion: {
+								data: { id: "pre-release-1" }
+							}
+						}
+					}
+				],
+				included: [
+					{
+						type: "preReleaseVersions",
+						id: "pre-release-1",
+						attributes: { version: $version_name }
+					}
+				]
+			}' >"$output_file"
+		else
+			printf '{"data":[],"included":[]}\n' >"$output_file"
+		fi
+		;;
+	*)
+		printf 'Unexpected URL: %s\n' "$url" >&2
+		exit 1
+		;;
+esac
+
+printf '200'
+SH
+	chmod +x "${bin_dir}/curl"
+
+	(
+		cd "${REPO_ROOT}"
+		PATH="${bin_dir}:${PATH}" \
+		RUNNER_TEMP="${temp_dir}" \
+		OSTYPE=darwin \
+		APP_STORE_CONNECT_CHECK_ONLY=1 \
+		APP_STORE_CONNECT_API_KEY_PATH="$api_key_path" \
+		APP_STORE_CONNECT_KEY_ID="TESTKEYID1" \
+		APP_STORE_CONNECT_ISSUER_ID="00000000-0000-0000-0000-000000000000" \
+		APP_STORE_CONNECT_BUILD_EXISTS_FILE="$exists_file" \
+		GITHUB_OUTPUT="$github_output" \
+		TUINDICE_APPSTORE_TEST_MODE="$name" \
+		TUINDICE_APPSTORE_TEST_VERSION_NAME="$VERSION_NAME" \
+			bash ./iosApp/scripts/ci-upload-ios-appstore.sh
+	)
+
+	assert_file_contains_line "$exists_file" "exists=${expected_exists}" "App Store Connect state"
+	assert_file_contains_line "$exists_file" "build_id=${expected_build_id}" "App Store Connect state"
+	assert_file_contains_line "$github_output" "ios_build_exists=${expected_exists}" "GitHub output"
+	assert_file_contains_line "$github_output" "ios_existing_build_id=${expected_build_id}" "GitHub output"
+}
+
+run_appstore_check_fixture missing false ""
+run_appstore_check_fixture exists true build-1
+
+printf 'App Store Connect check-only fixtures passed for %s (%s).\n' "$VERSION_NAME" "$IOS_BUILD_NUMBER"

--- a/.github/scripts/test-detect-changed-app.sh
+++ b/.github/scripts/test-detect-changed-app.sh
@@ -45,15 +45,18 @@ run_detector_fixture() {
 	local temp_dir
 	local changed_files_file
 	local output_file
+	local github_output_file
 
 	temp_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/tuindice-detect-test.XXXXXX")"
 	changed_files_file="${temp_dir}/changed-files.txt"
 	output_file="${temp_dir}/output.log"
+	github_output_file="${temp_dir}/github-output.txt"
 	printf '%s\n' "$changed_path" >"$changed_files_file"
 
 	(
 		cd "${REPO_ROOT}"
 		STATE_DIR="${temp_dir}/state" \
+		GITHUB_OUTPUT="$github_output_file" \
 		DETECT_CHANGED_APP_CHANGED_FILES_FILE="$changed_files_file" \
 			bash ./.github/scripts/detect-changed-app.sh "$HEAD_SHA" "$HEAD_SHA"
 	) >"$output_file" 2>&1
@@ -67,6 +70,7 @@ run_detector_fixture() {
 			assert_file_empty "${temp_dir}/state/e2e-scope.csv" "E2E scope"
 			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" "verifyAppVersionSync" "Android tasks"
 			assert_file_empty "${temp_dir}/state/ios-gradle-tasks.txt" "iOS tasks"
+			assert_file_contains_line "$github_output_file" "ios_ci_scripts_touched=true" "GitHub output"
 			;;
 		ios-host-runtime)
 			assert_file_contains_line "${temp_dir}/state/impacted-modules.txt" "iosApp" "impacted modules"
@@ -75,6 +79,7 @@ run_detector_fixture() {
 			assert_file_contains_line "${temp_dir}/state/e2e-scope.csv" "ios,local-certification-suite,ios-host-runtime" "E2E scope"
 			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildRelease" "iOS tasks"
 			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
+			assert_file_contains_line "$github_output_file" "ios_ci_scripts_touched=false" "GitHub output"
 			;;
 		*)
 			printf 'Unknown detector fixture: %s\n' "$name" >&2

--- a/.github/scripts/test-google-play-draft-check.sh
+++ b/.github/scripts/test-google-play-draft-check.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=.github/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+require_tool jq
+
+VERSION_NAME="$(get_app_version_name)"
+ANDROID_VERSION_CODE="$(get_android_version_code)"
+
+assert_file_contains_line() {
+	local file="$1"
+	local expected="$2"
+	local label="$3"
+
+	if ! grep -Fxq "$expected" "$file"; then
+		printf 'Expected %s to contain "%s", got:\n' "$label" "$expected" >&2
+		cat "$file" >&2 || true
+		exit 1
+	fi
+}
+
+run_google_play_check_fixture() {
+	local name="$1"
+	local expected_exists="$2"
+	local expected_status="$3"
+	local temp_dir
+	local bin_dir
+	local github_output
+	local exists_file
+
+	temp_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/tuindice-google-play-check-test.XXXXXX")"
+	bin_dir="${temp_dir}/bin"
+	github_output="${temp_dir}/github-output.txt"
+	exists_file="${temp_dir}/android-release-exists.env"
+	mkdir -p "$bin_dir"
+
+	cat >"${bin_dir}/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${TUINDICE_GOOGLE_PLAY_TEST_MODE:?}"
+version_code="${TUINDICE_GOOGLE_PLAY_TEST_VERSION_CODE:?}"
+method="GET"
+output_file=""
+url=""
+
+while [[ "$#" -gt 0 ]]; do
+	case "$1" in
+		-X)
+			method="$2"
+			shift 2
+			;;
+		-H|-o|-w)
+			if [[ "$1" == "-o" ]]; then
+				output_file="$2"
+			fi
+			shift 2
+			;;
+		--data-binary)
+			shift 2
+			;;
+		--fail|--silent|--show-error)
+			shift
+			;;
+		*)
+			url="$1"
+			shift
+			;;
+	esac
+done
+
+case "$method:$url" in
+	POST:*/edits)
+		printf '{"id":"edit-1"}\n'
+		;;
+	GET:*/tracks/*)
+		[[ -n "$output_file" ]] || {
+			printf 'Expected curl -o output file.\n' >&2
+			exit 1
+		}
+		if [[ "$mode" == "exists" ]]; then
+			jq -n --argjson version_code "$version_code" '{
+				releases: [
+					{
+						status: "draft",
+						versionCodes: [$version_code]
+					}
+				]
+			}' >"$output_file"
+		else
+			printf '{"releases":[]}\n' >"$output_file"
+		fi
+		printf '200'
+		;;
+	DELETE:*/edits/*)
+		;;
+	*)
+		printf 'Unexpected Google Play API call: %s %s\n' "$method" "$url" >&2
+		exit 1
+		;;
+esac
+SH
+	chmod +x "${bin_dir}/curl"
+
+	(
+		cd "${REPO_ROOT}"
+		PATH="${bin_dir}:${PATH}" \
+		RUNNER_TEMP="${temp_dir}" \
+		ANDROID_PUBLISHER_ACCESS_TOKEN="test-token" \
+		GOOGLE_PLAY_CHECK_ONLY=1 \
+		GOOGLE_PLAY_RELEASE_EXISTS_FILE="$exists_file" \
+		GITHUB_OUTPUT="$github_output" \
+		TUINDICE_GOOGLE_PLAY_TEST_MODE="$name" \
+		TUINDICE_GOOGLE_PLAY_TEST_VERSION_CODE="$ANDROID_VERSION_CODE" \
+			bash ./.github/scripts/publish-google-play-draft.sh
+	)
+
+	assert_file_contains_line "$exists_file" "exists=${expected_exists}" "Google Play state"
+	assert_file_contains_line "$exists_file" "status=${expected_status}" "Google Play state"
+	assert_file_contains_line "$github_output" "android_draft_exists=${expected_exists}" "GitHub output"
+	assert_file_contains_line "$github_output" "android_draft_status=${expected_status}" "GitHub output"
+}
+
+run_google_play_check_fixture missing false ""
+run_google_play_check_fixture exists true draft
+
+printf 'Google Play check-only fixtures passed for %s (%s).\n' "$VERSION_NAME" "$ANDROID_VERSION_CODE"

--- a/.github/scripts/validate-ci-config.sh
+++ b/.github/scripts/validate-ci-config.sh
@@ -8,6 +8,14 @@ source "${SCRIPT_DIR}/common.sh"
 
 require_tool bash
 
+mktemp_portability_violations="$(
+	grep -R -n -E 'mktemp [^#]*XXXXXX[[:alnum:]_.-]+' .github/scripts e2e/scripts iosApp/scripts 2>/dev/null || true
+)"
+if [[ -n "$mktemp_portability_violations" ]]; then
+	printf '%s\n' "$mktemp_portability_violations" >&2
+	die "mktemp templates must end in XXXXXX for macOS portability."
+fi
+
 while IFS= read -r script_file; do
 	[[ -n "$script_file" ]] || continue
 	info "Checking shell syntax: ${script_file}"
@@ -25,5 +33,7 @@ done < <(
 
 bash "${SCRIPT_DIR}/test-preflight-production.sh"
 bash "${SCRIPT_DIR}/test-detect-changed-app.sh"
+bash "${SCRIPT_DIR}/test-google-play-draft-check.sh"
+bash "${SCRIPT_DIR}/test-appstore-connect-check.sh"
 
 info "CI configuration syntax checks passed."

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -41,7 +41,7 @@ jobs:
           bash ./.github/scripts/deploy-production.sh
 
   deploy-android:
-    name: Deploy Android draft
+    name: Deploy Android
     runs-on: ubuntu-24.04
     needs: deploy-preflight
     environment: production
@@ -100,7 +100,7 @@ jobs:
           bash ./.github/scripts/deploy-production.sh
 
   deploy-ios:
-    name: Deploy iOS build
+    name: Deploy iOS
     runs-on: macos-26
     needs: deploy-preflight
     environment: production

--- a/.github/workflows/preflight-production-pr.yml
+++ b/.github/workflows/preflight-production-pr.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       android_tasks: ${{ steps.changes.outputs.android_tasks }}
       ios_tasks: ${{ steps.changes.outputs.ios_tasks }}
+      ios_ci_scripts_touched: ${{ steps.changes.outputs.ios_ci_scripts_touched }}
       has_relevant_changes: ${{ steps.changes.outputs.has_relevant_changes }}
 
     steps:
@@ -131,7 +132,7 @@ jobs:
     timeout-minutes: 90
     needs:
       - shared-preflight
-    if: ${{ !cancelled() && needs.shared-preflight.result == 'success' && needs.shared-preflight.outputs.ios_tasks != '' }}
+    if: ${{ !cancelled() && needs.shared-preflight.result == 'success' && (needs.shared-preflight.outputs.ios_tasks != '' || needs.shared-preflight.outputs.ios_ci_scripts_touched == 'true') }}
 
     steps:
       - name: Check out repository
@@ -140,22 +141,32 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Run iOS CI script smoke checks
+        if: needs.shared-preflight.outputs.ios_ci_scripts_touched == 'true'
+        run: |
+          set -euo pipefail
+          bash ./.github/scripts/test-appstore-connect-check.sh
+
       - name: Set up Xcode
+        if: needs.shared-preflight.outputs.ios_tasks != ''
         run: |
           set -euo pipefail
           sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
           xcodebuild -version
 
       - name: Set up Java
+        if: needs.shared-preflight.outputs.ios_tasks != ''
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Set up Gradle
+        if: needs.shared-preflight.outputs.ios_tasks != ''
         uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
 
       - name: Install CocoaPods dependencies
+        if: needs.shared-preflight.outputs.ios_tasks != ''
         run: |
           set -euo pipefail
           if command -v pod >/dev/null 2>&1; then
@@ -175,6 +186,7 @@ jobs:
           REQUIRE_FIREBASE_CONFIGS=1 bash ./.github/scripts/materialize-firebase-configs.sh
 
       - name: Run focused iOS checks
+        if: needs.shared-preflight.outputs.ios_tasks != ''
         env:
           TUINDICE_IOS_HOST_BUILD: "1"
           PLATFORM_NAME: iphonesimulator
@@ -209,6 +221,7 @@ jobs:
           ios_result="${{ needs.ios-preflight.result }}"
           android_tasks="${{ needs.shared-preflight.outputs.android_tasks }}"
           ios_tasks="${{ needs.shared-preflight.outputs.ios_tasks }}"
+          ios_ci_scripts_touched="${{ needs.shared-preflight.outputs.ios_ci_scripts_touched }}"
           echo "Shared preflight result: ${shared_result}"
           echo "Android preflight result: ${android_result}"
           echo "iOS preflight result: ${ios_result}"
@@ -218,6 +231,6 @@ jobs:
           if [[ -n "${android_tasks}" && "${android_result}" != "success" ]]; then
             exit 1
           fi
-          if [[ -n "${ios_tasks}" && "${ios_result}" != "success" ]]; then
+          if [[ ( -n "${ios_tasks}" || "${ios_ci_scripts_touched}" == "true" ) && "${ios_result}" != "success" ]]; then
             exit 1
           fi

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -96,7 +96,15 @@ El deploy construye artefactos firmados y publica drafts:
 - Crashlytics: el mapping file se sube solo en deploy real con `TUINDICE_UPLOAD_CRASHLYTICS_MAPPING=1`.
 - Tag: `app-<versionName>` anotado al SHA de `production`, creado solo después de ambos uploads.
 
-Dry-run local o en CI:
+Preflight local sin secretos:
+
+```bash
+DEPLOY_DIFF_BASE_SHA="$(git merge-base production HEAD)" \
+DEPLOY_PRODUCTION_PHASE=preflight \
+bash ./.github/scripts/deploy-production.sh
+```
+
+Dry-run local o en CI, construyendo artefactos firmados pero sin publicar:
 
 ```bash
 DRY_RUN=1 bash ./.github/scripts/deploy-production.sh

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -42,6 +42,7 @@ El detector compara el PR contra el merge-base de `production` y ejecuta solo pi
 - Cambios en `base`, `persistence`, `academiccore`, `maincore`, Gradle raíz o hosts amplían el alcance.
 - Cambios runtime exigen bump de versión.
 - Cambios user-visible cubiertos por E2E exigen commit statuses locales exitosos.
+- Cambios en `iosApp/scripts/*` disparan un smoke liviano en macOS dentro de `iOS preflight`, sin compilar el host si no hay tareas iOS.
 
 Validación local del detector:
 

--- a/iosApp/scripts/ci-upload-ios-appstore.sh
+++ b/iosApp/scripts/ci-upload-ios-appstore.sh
@@ -156,8 +156,8 @@ check_app_store_connect_build_exists() {
 	export APP_STORE_CONNECT_KEY_ID APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_API_KEY_PATH
 	APP_STORE_CONNECT_JWT="$(generate_app_store_connect_jwt)"
 
-	apps_response="$(mktemp "${RUNNER_TEMP:-/tmp}/tuindice-appstore-apps.XXXXXX.json")"
-	builds_response="$(mktemp "${RUNNER_TEMP:-/tmp}/tuindice-appstore-builds.XXXXXX.json")"
+	apps_response="$(mktemp "${RUNNER_TEMP:-/tmp}/tuindice-appstore-apps.XXXXXX")"
+	builds_response="$(mktemp "${RUNNER_TEMP:-/tmp}/tuindice-appstore-builds.XXXXXX")"
 
 	app_store_connect_get_json "${APP_STORE_CONNECT_API_ROOT}/apps?filter%5BbundleId%5D=${IOS_BUNDLE_IDENTIFIER}&limit=1" "$apps_response"
 	app_id="$(jq -r '.data[0].id // empty' "$apps_response")"


### PR DESCRIPTION
## Summary
- Rename production deploy job labels to Deploy Android and Deploy iOS.
- Fix iOS App Store Connect temp file creation on macOS.
- Add mock smoke tests for Google Play and App Store Connect deploy checks.
- Document preflight vs signed dry-run behavior.

## Validation
- bash ./.github/scripts/validate-ci-config.sh
- DEPLOY_DIFF_BASE_SHA=origin/production TARGET_GIT_SHA=HEAD DEPLOY_PRODUCTION_PHASE=preflight bash ./.github/scripts/deploy-production.sh
- git diff --check