### PR TITLE
Fix production release build numbers

### DIFF
--- a/.github/gradle/ios-host-cache.init.gradle.kts
+++ b/.github/gradle/ios-host-cache.init.gradle.kts
@@ -1,0 +1,31 @@
+import org.gradle.api.tasks.Exec
+
+private fun iosFrameworkBinary(rootDir: File, targetName: String, buildType: String): File =
+	rootDir.resolve("maincore/build/bin/$targetName/${buildType.lowercase()}Framework/maincore.framework/maincore")
+
+private fun shouldUseCachedIosFramework(rootDir: File, targetName: String, buildType: String): Boolean =
+	System.getenv("TUINDICE_IOS_USE_CACHED_FRAMEWORK") == "1" &&
+		iosFrameworkBinary(rootDir, targetName, buildType).isFile
+
+gradle.projectsEvaluated {
+	rootProject.tasks.named("verifyIosHostBuildDeviceRelease", Exec::class.java).configure {
+		val useCachedReleaseFramework = shouldUseCachedIosFramework(rootProject.rootDir, "iosArm64", "Release")
+
+		if (!useCachedReleaseFramework) {
+			dependsOn(":maincore:linkReleaseFrameworkIosArm64")
+		}
+		dependsOn(":maincore:syncComposeResourcesForIos")
+
+		environment("SKIP_FRAMEWORK_BUILD", "1")
+		environment(
+			"CODE_SIGNING_ALLOWED",
+			System.getenv("TUINDICE_IOS_HOST_DEVICE_CODE_SIGNING_ALLOWED") ?: "NO"
+		)
+
+		doFirst {
+			if (useCachedReleaseFramework) {
+				logger.lifecycle("Using cached iOS device release framework for verifyIosHostBuildDeviceRelease.")
+			}
+		}
+	}
+}

--- a/.github/scripts/detect-changed-app.sh
+++ b/.github/scripts/detect-changed-app.sh
@@ -35,6 +35,9 @@ mkdir -p "$STATE_DIR"
 
 APP_VERSION_TOUCHED=false
 APP_VERSION_CHANGED=false
+APP_VERSION_NAME_CHANGED=false
+ANDROID_VERSION_CODE_CHANGED=false
+IOS_BUILD_NUMBER_CHANGED=false
 CI_CONFIG_TOUCHED=false
 IOS_CI_SCRIPTS_TOUCHED=false
 E2E_CONTRACT_TOUCHED=false
@@ -204,7 +207,6 @@ append_ios_signing_config_validation() {
 	CI_CONFIG_TOUCHED=true
 	HAS_RELEVANT_CHANGES=true
 	append_unique_line "$IOS_TASKS_FILE" "verifyIosHostBuildRelease"
-	append_unique_line "$IOS_TASKS_FILE" "verifyIosHostTypecheck"
 }
 
 is_ios_signing_only_config_change() {
@@ -327,6 +329,11 @@ classify_changed_file() {
 			return 0
 			;;
 		"$(app_version_file)")
+			APP_VERSION_TOUCHED=true
+			HAS_RELEVANT_CHANGES=true
+			return 0
+			;;
+		iosApp/Config/Version.xcconfig)
 			APP_VERSION_TOUCHED=true
 			HAS_RELEVANT_CHANGES=true
 			return 0
@@ -470,9 +477,27 @@ if [[ "$APP_VERSION_TOUCHED" == "true" ]]; then
 	base_ios_build="$(get_app_version_property_at_git_ref iosBuildNumber "$BEFORE_SHA")"
 	head_ios_build="$(get_app_version_property_at_git_ref iosBuildNumber "$AFTER_SHA")"
 
-	if [[ "$base_version" != "$head_version" || "$base_android_code" != "$head_android_code" || "$base_ios_build" != "$head_ios_build" ]]; then
+	if [[ "$base_version" != "$head_version" ]]; then
+		APP_VERSION_NAME_CHANGED=true
+	fi
+	if [[ "$base_android_code" != "$head_android_code" ]]; then
+		ANDROID_VERSION_CODE_CHANGED=true
+	fi
+	if [[ "$base_ios_build" != "$head_ios_build" ]]; then
+		IOS_BUILD_NUMBER_CHANGED=true
+	fi
+
+	if [[ "$APP_VERSION_NAME_CHANGED" == "true" || "$ANDROID_VERSION_CODE_CHANGED" == "true" || "$IOS_BUILD_NUMBER_CHANGED" == "true" ]]; then
 		APP_VERSION_CHANGED=true
 	fi
+fi
+
+if [[ "$APP_VERSION_NAME_CHANGED" == "true" || "$ANDROID_VERSION_CODE_CHANGED" == "true" ]]; then
+	append_runtime_module app
+fi
+
+if [[ "$APP_VERSION_NAME_CHANGED" == "true" || "$IOS_BUILD_NUMBER_CHANGED" == "true" ]]; then
+	append_runtime_module iosApp
 fi
 
 if [[ "$HAS_RELEASE_IMPACT" == "true" && "$APP_VERSION_CHANGED" != "true" ]]; then
@@ -498,9 +523,10 @@ while IFS= read -r module; do
 			fi
 			;;
 		iosApp)
-			append_unique_line "$IOS_TASKS_FILE" "verifyIosHostTypecheck"
 			if [[ "$HAS_RELEASE_IMPACT" == "true" || "$APP_VERSION_CHANGED" == "true" ]]; then
 				append_unique_line "$IOS_TASKS_FILE" "verifyIosHostBuildRelease"
+			else
+				append_unique_line "$IOS_TASKS_FILE" "verifyIosHostTypecheck"
 			fi
 			;;
 		*)

--- a/.github/scripts/detect-changed-app.sh
+++ b/.github/scripts/detect-changed-app.sh
@@ -206,7 +206,7 @@ mark_e2e_suite_for_module() {
 append_ios_signing_config_validation() {
 	CI_CONFIG_TOUCHED=true
 	HAS_RELEVANT_CHANGES=true
-	append_unique_line "$IOS_TASKS_FILE" "verifyIosHostBuildRelease"
+	append_unique_line "$IOS_TASKS_FILE" "verifyIosHostBuildDeviceRelease"
 }
 
 is_ios_signing_only_config_change() {
@@ -524,7 +524,7 @@ while IFS= read -r module; do
 			;;
 		iosApp)
 			if [[ "$HAS_RELEASE_IMPACT" == "true" || "$APP_VERSION_CHANGED" == "true" ]]; then
-				append_unique_line "$IOS_TASKS_FILE" "verifyIosHostBuildRelease"
+				append_unique_line "$IOS_TASKS_FILE" "verifyIosHostBuildDeviceRelease"
 			else
 				append_unique_line "$IOS_TASKS_FILE" "verifyIosHostTypecheck"
 			fi

--- a/.github/scripts/ios-framework-cache-key.sh
+++ b/.github/scripts/ios-framework-cache-key.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "$REPO_ROOT"
+
+declare -a cache_inputs=(
+	"gradle/wrapper/gradle-wrapper.properties"
+	"gradle/libs.versions.toml"
+	"gradle.properties"
+	"settings.gradle.kts"
+	"build.gradle.kts"
+	"iosApp/scripts/build-kmp-framework.sh"
+	"academiccore/build.gradle.kts"
+	"academiccore/src"
+	"base/build.gradle.kts"
+	"base/src"
+	"persistence/build.gradle.kts"
+	"persistence/src"
+	"auth/build.gradle.kts"
+	"auth/src"
+	"about/build.gradle.kts"
+	"about/src"
+	"summary/build.gradle.kts"
+	"summary/src"
+	"record/build.gradle.kts"
+	"record/src"
+	"evaluations/build.gradle.kts"
+	"evaluations/src"
+	"enrollmentproof/build.gradle.kts"
+	"enrollmentproof/src"
+	"subjects/build.gradle.kts"
+	"subjects/src"
+	"pensum/build.gradle.kts"
+	"pensum/src"
+	"wizard/build.gradle.kts"
+	"wizard/src"
+	"maincore/build.gradle.kts"
+	"maincore/src"
+)
+
+git ls-files -- "${cache_inputs[@]}" \
+	| LC_ALL=C sort \
+	| while IFS= read -r file_path; do
+		shasum -a 256 "$file_path"
+	done \
+	| shasum -a 256 \
+	| awk '{ print $1 }'

--- a/.github/scripts/test-detect-changed-app.sh
+++ b/.github/scripts/test-detect-changed-app.sh
@@ -15,6 +15,7 @@ require_tool() {
 require_tool git
 
 HEAD_SHA="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+APP_VERSION_FILE="gradle/app-version.properties"
 
 assert_file_empty() {
 	local file="$1"
@@ -39,9 +40,78 @@ assert_file_contains_line() {
 	fi
 }
 
+assert_file_not_contains_line() {
+	local file="$1"
+	local unexpected="$2"
+	local label="$3"
+
+	if grep -Fxq "$unexpected" "$file"; then
+		printf 'Expected %s not to contain "%s", got:\n' "$label" "$unexpected" >&2
+		cat "$file" >&2 || true
+		exit 1
+	fi
+}
+
+app_version_property() {
+	local property_name="$1"
+
+	awk -F= -v property_name="$property_name" '
+		$1 == property_name {
+			value = $2
+			gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+			print value
+			exit
+		}
+	' "${REPO_ROOT}/${APP_VERSION_FILE}"
+}
+
+increment_patch_version() {
+	local version="$1"
+	local major
+	local minor
+	local patch
+
+	IFS=. read -r major minor patch <<<"$version"
+	printf '%s.%s.%s\n' "$major" "$minor" "$((patch + 1))"
+}
+
+create_app_version_commit() {
+	local name="$1"
+	local version_name="$2"
+	local android_version_code="$3"
+	local ios_build_number="$4"
+	local temp_dir
+	local index_file
+	local version_file
+	local blob_sha
+	local tree_sha
+
+	temp_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/tuindice-version-detect-test.XXXXXX")"
+	index_file="${temp_dir}/index"
+	version_file="${temp_dir}/app-version.properties"
+
+	printf 'versionName=%s\nandroidVersionCode=%s\niosBuildNumber=%s\n' \
+		"$version_name" \
+		"$android_version_code" \
+		"$ios_build_number" >"$version_file"
+
+	GIT_INDEX_FILE="$index_file" git -C "${REPO_ROOT}" read-tree "$HEAD_SHA"
+	blob_sha="$(git -C "${REPO_ROOT}" hash-object -w "$version_file")"
+	GIT_INDEX_FILE="$index_file" git -C "${REPO_ROOT}" update-index --add --cacheinfo "100644,${blob_sha},${APP_VERSION_FILE}"
+	tree_sha="$(GIT_INDEX_FILE="$index_file" git -C "${REPO_ROOT}" write-tree)"
+
+	GIT_AUTHOR_NAME="TuIndice CI Test" \
+		GIT_AUTHOR_EMAIL="tuindice-ci-test@example.invalid" \
+		GIT_COMMITTER_NAME="TuIndice CI Test" \
+		GIT_COMMITTER_EMAIL="tuindice-ci-test@example.invalid" \
+		git -C "${REPO_ROOT}" commit-tree "$tree_sha" -p "$HEAD_SHA" -m "test ${name}"
+}
+
 run_detector_fixture() {
 	local name="$1"
 	local changed_path="$2"
+	local before_sha="${3:-$HEAD_SHA}"
+	local after_sha="${4:-$HEAD_SHA}"
 	local temp_dir
 	local changed_files_file
 	local output_file
@@ -58,7 +128,7 @@ run_detector_fixture() {
 		STATE_DIR="${temp_dir}/state" \
 		GITHUB_OUTPUT="$github_output_file" \
 		DETECT_CHANGED_APP_CHANGED_FILES_FILE="$changed_files_file" \
-			bash ./.github/scripts/detect-changed-app.sh "$HEAD_SHA" "$HEAD_SHA"
+			bash ./.github/scripts/detect-changed-app.sh "$before_sha" "$after_sha"
 	) >"$output_file" 2>&1
 
 	case "$name" in
@@ -78,8 +148,48 @@ run_detector_fixture() {
 			assert_file_contains_line "${temp_dir}/state/missing-version-bump.txt" "app" "missing version bump"
 			assert_file_contains_line "${temp_dir}/state/e2e-scope.csv" "ios,local-certification-suite,ios-host-runtime" "E2E scope"
 			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildRelease" "iOS tasks"
-			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
+			assert_file_not_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
 			assert_file_contains_line "$github_output_file" "ios_ci_scripts_touched=false" "GitHub output"
+			;;
+		ios-version-xcconfig)
+			assert_file_empty "${temp_dir}/state/impacted-modules.txt" "impacted modules"
+			assert_file_empty "${temp_dir}/state/release-impacted-modules.txt" "release impacted modules"
+			assert_file_empty "${temp_dir}/state/missing-version-bump.txt" "missing version bump"
+			assert_file_empty "${temp_dir}/state/e2e-scope.csv" "E2E scope"
+			assert_file_empty "${temp_dir}/state/android-gradle-tasks.txt" "Android tasks"
+			assert_file_empty "${temp_dir}/state/ios-gradle-tasks.txt" "iOS tasks"
+			assert_file_contains_line "$github_output_file" "app_version_touched=true" "GitHub output"
+			assert_file_contains_line "$github_output_file" "app_version_changed=false" "GitHub output"
+			;;
+		android-version-code)
+			assert_file_contains_line "${temp_dir}/state/impacted-modules.txt" "app" "impacted modules"
+			assert_file_contains_line "${temp_dir}/state/release-impacted-modules.txt" "app" "release impacted modules"
+			assert_file_empty "${temp_dir}/state/e2e-scope.csv" "E2E scope"
+			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" ":app:testDebugUnitTest" "Android tasks"
+			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" ":app:bundleRelease" "Android tasks"
+			assert_file_empty "${temp_dir}/state/ios-gradle-tasks.txt" "iOS tasks"
+			assert_file_contains_line "$github_output_file" "app_version_changed=true" "GitHub output"
+			;;
+		ios-build-number)
+			assert_file_contains_line "${temp_dir}/state/impacted-modules.txt" "iosApp" "impacted modules"
+			assert_file_contains_line "${temp_dir}/state/release-impacted-modules.txt" "iosApp" "release impacted modules"
+			assert_file_empty "${temp_dir}/state/e2e-scope.csv" "E2E scope"
+			assert_file_empty "${temp_dir}/state/android-gradle-tasks.txt" "Android tasks"
+			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildRelease" "iOS tasks"
+			assert_file_not_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
+			assert_file_contains_line "$github_output_file" "app_version_changed=true" "GitHub output"
+			;;
+		version-name)
+			assert_file_contains_line "${temp_dir}/state/impacted-modules.txt" "app" "impacted modules"
+			assert_file_contains_line "${temp_dir}/state/impacted-modules.txt" "iosApp" "impacted modules"
+			assert_file_contains_line "${temp_dir}/state/release-impacted-modules.txt" "app" "release impacted modules"
+			assert_file_contains_line "${temp_dir}/state/release-impacted-modules.txt" "iosApp" "release impacted modules"
+			assert_file_empty "${temp_dir}/state/e2e-scope.csv" "E2E scope"
+			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" ":app:testDebugUnitTest" "Android tasks"
+			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" ":app:bundleRelease" "Android tasks"
+			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildRelease" "iOS tasks"
+			assert_file_not_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
+			assert_file_contains_line "$github_output_file" "app_version_changed=true" "GitHub output"
 			;;
 		*)
 			printf 'Unknown detector fixture: %s\n' "$name" >&2
@@ -88,7 +198,37 @@ run_detector_fixture() {
 	esac
 }
 
+current_version_name="$(app_version_property versionName)"
+current_android_version_code="$(app_version_property androidVersionCode)"
+current_ios_build_number="$(app_version_property iosBuildNumber)"
+
+android_version_commit="$(
+	create_app_version_commit \
+		android-version-code \
+		"$current_version_name" \
+		"$((current_android_version_code + 1))" \
+		"$current_ios_build_number"
+)"
+ios_build_commit="$(
+	create_app_version_commit \
+		ios-build-number \
+		"$current_version_name" \
+		"$current_android_version_code" \
+		"$((current_ios_build_number + 1))"
+)"
+version_name_commit="$(
+	create_app_version_commit \
+		version-name \
+		"$(increment_patch_version "$current_version_name")" \
+		"$current_android_version_code" \
+		"$current_ios_build_number"
+)"
+
 run_detector_fixture ios-script-tooling iosApp/scripts/ci-upload-ios-appstore.sh
 run_detector_fixture ios-host-runtime iosApp/Sources/TuIndiceHost/TuIndiceAppBootstrap.swift
+run_detector_fixture ios-version-xcconfig iosApp/Config/Version.xcconfig
+run_detector_fixture android-version-code "$APP_VERSION_FILE" "$HEAD_SHA" "$android_version_commit"
+run_detector_fixture ios-build-number "$APP_VERSION_FILE" "$HEAD_SHA" "$ios_build_commit"
+run_detector_fixture version-name "$APP_VERSION_FILE" "$HEAD_SHA" "$version_name_commit"
 
 printf 'Detect changed app shell fixtures passed.\n'

--- a/.github/scripts/test-detect-changed-app.sh
+++ b/.github/scripts/test-detect-changed-app.sh
@@ -107,6 +107,45 @@ create_app_version_commit() {
 		git -C "${REPO_ROOT}" commit-tree "$tree_sha" -p "$HEAD_SHA" -m "test ${name}"
 }
 
+create_file_commit() {
+	local name="$1"
+	local file_path="$2"
+	local source_file="$3"
+	local temp_dir
+	local index_file
+	local blob_sha
+	local tree_sha
+
+	temp_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/tuindice-file-detect-test.XXXXXX")"
+	index_file="${temp_dir}/index"
+
+	GIT_INDEX_FILE="$index_file" git -C "${REPO_ROOT}" read-tree "$HEAD_SHA"
+	blob_sha="$(git -C "${REPO_ROOT}" hash-object -w "$source_file")"
+	GIT_INDEX_FILE="$index_file" git -C "${REPO_ROOT}" update-index --add --cacheinfo "100644,${blob_sha},${file_path}"
+	tree_sha="$(GIT_INDEX_FILE="$index_file" git -C "${REPO_ROOT}" write-tree)"
+
+	GIT_AUTHOR_NAME="TuIndice CI Test" \
+		GIT_AUTHOR_EMAIL="tuindice-ci-test@example.invalid" \
+		GIT_COMMITTER_NAME="TuIndice CI Test" \
+		GIT_COMMITTER_EMAIL="tuindice-ci-test@example.invalid" \
+		git -C "${REPO_ROOT}" commit-tree "$tree_sha" -p "$HEAD_SHA" -m "test ${name}"
+}
+
+create_ios_release_signing_commit() {
+	local name="$1"
+	local file_path="iosApp/Config/Release.xcconfig"
+	local temp_dir
+	local release_config_file
+
+	temp_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/tuindice-ios-signing-detect-test.XXXXXX")"
+	release_config_file="${temp_dir}/Release.xcconfig"
+	git -C "${REPO_ROOT}" show "${HEAD_SHA}:${file_path}" \
+		| sed 's/^TUINDICE_CODE_SIGN_STYLE = .*/TUINDICE_CODE_SIGN_STYLE = Manual/' \
+		>"$release_config_file"
+
+	create_file_commit "$name" "$file_path" "$release_config_file"
+}
+
 run_detector_fixture() {
 	local name="$1"
 	local changed_path="$2"
@@ -147,7 +186,7 @@ run_detector_fixture() {
 			assert_file_contains_line "${temp_dir}/state/release-impacted-modules.txt" "iosApp" "release impacted modules"
 			assert_file_contains_line "${temp_dir}/state/missing-version-bump.txt" "app" "missing version bump"
 			assert_file_contains_line "${temp_dir}/state/e2e-scope.csv" "ios,local-certification-suite,ios-host-runtime" "E2E scope"
-			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildRelease" "iOS tasks"
+			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildDeviceRelease" "iOS tasks"
 			assert_file_not_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
 			assert_file_contains_line "$github_output_file" "ios_ci_scripts_touched=false" "GitHub output"
 			;;
@@ -160,6 +199,15 @@ run_detector_fixture() {
 			assert_file_empty "${temp_dir}/state/ios-gradle-tasks.txt" "iOS tasks"
 			assert_file_contains_line "$github_output_file" "app_version_touched=true" "GitHub output"
 			assert_file_contains_line "$github_output_file" "app_version_changed=false" "GitHub output"
+			;;
+		ios-release-signing)
+			assert_file_empty "${temp_dir}/state/impacted-modules.txt" "impacted modules"
+			assert_file_empty "${temp_dir}/state/release-impacted-modules.txt" "release impacted modules"
+			assert_file_empty "${temp_dir}/state/missing-version-bump.txt" "missing version bump"
+			assert_file_empty "${temp_dir}/state/e2e-scope.csv" "E2E scope"
+			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" "verifyAppVersionSync" "Android tasks"
+			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildDeviceRelease" "iOS tasks"
+			assert_file_contains_line "$github_output_file" "ci_config_touched=true" "GitHub output"
 			;;
 		android-version-code)
 			assert_file_contains_line "${temp_dir}/state/impacted-modules.txt" "app" "impacted modules"
@@ -175,7 +223,7 @@ run_detector_fixture() {
 			assert_file_contains_line "${temp_dir}/state/release-impacted-modules.txt" "iosApp" "release impacted modules"
 			assert_file_empty "${temp_dir}/state/e2e-scope.csv" "E2E scope"
 			assert_file_empty "${temp_dir}/state/android-gradle-tasks.txt" "Android tasks"
-			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildRelease" "iOS tasks"
+			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildDeviceRelease" "iOS tasks"
 			assert_file_not_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
 			assert_file_contains_line "$github_output_file" "app_version_changed=true" "GitHub output"
 			;;
@@ -187,7 +235,7 @@ run_detector_fixture() {
 			assert_file_empty "${temp_dir}/state/e2e-scope.csv" "E2E scope"
 			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" ":app:testDebugUnitTest" "Android tasks"
 			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" ":app:bundleRelease" "Android tasks"
-			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildRelease" "iOS tasks"
+			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildDeviceRelease" "iOS tasks"
 			assert_file_not_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
 			assert_file_contains_line "$github_output_file" "app_version_changed=true" "GitHub output"
 			;;
@@ -223,10 +271,14 @@ version_name_commit="$(
 		"$current_android_version_code" \
 		"$current_ios_build_number"
 )"
+ios_release_signing_commit="$(
+	create_ios_release_signing_commit ios-release-signing
+)"
 
 run_detector_fixture ios-script-tooling iosApp/scripts/ci-upload-ios-appstore.sh
 run_detector_fixture ios-host-runtime iosApp/Sources/TuIndiceHost/TuIndiceAppBootstrap.swift
 run_detector_fixture ios-version-xcconfig iosApp/Config/Version.xcconfig
+run_detector_fixture ios-release-signing iosApp/Config/Release.xcconfig "$HEAD_SHA" "$ios_release_signing_commit"
 run_detector_fixture android-version-code "$APP_VERSION_FILE" "$HEAD_SHA" "$android_version_commit"
 run_detector_fixture ios-build-number "$APP_VERSION_FILE" "$HEAD_SHA" "$ios_build_commit"
 run_detector_fixture version-name "$APP_VERSION_FILE" "$HEAD_SHA" "$version_name_commit"

--- a/.github/scripts/validate-ci-config.sh
+++ b/.github/scripts/validate-ci-config.sh
@@ -31,6 +31,12 @@ done < <(
 	find .github/workflows \( -name '*.yml' -o -name '*.yaml' \) -type f 2>/dev/null | sort
 )
 
+ios_framework_cache_hash="$(bash "${SCRIPT_DIR}/ios-framework-cache-key.sh")"
+if [[ ! "$ios_framework_cache_hash" =~ ^[0-9a-f]{64}$ ]]; then
+	die "iOS framework cache key script returned an invalid hash: ${ios_framework_cache_hash}"
+fi
+info "Validated iOS framework cache key hash."
+
 bash "${SCRIPT_DIR}/test-preflight-production.sh"
 bash "${SCRIPT_DIR}/test-detect-changed-app.sh"
 bash "${SCRIPT_DIR}/test-google-play-draft-check.sh"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -131,6 +131,52 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
           xcodebuild -version
 
+      - name: Resolve iOS cache metadata
+        id: ios-cache-metadata
+        if: steps.ios-build-check.outputs.ios_build_exists != 'true'
+        run: |
+          set -euo pipefail
+          xcode_cache_id="$(
+            xcodebuild -version \
+              | tr '\n' ' ' \
+              | sed -E 's/[[:space:]]+/ /g; s/[[:space:]]+$//; s/[[:space:]]/-/g'
+          )"
+          kotlin_version="$(
+            sed -n 's/^kotlin = "\(.*\)"/\1/p' gradle/libs.versions.toml | head -n 1
+          )"
+          framework_hash="$(bash ./.github/scripts/ios-framework-cache-key.sh)"
+          echo "xcode=${xcode_cache_id}" >> "$GITHUB_OUTPUT"
+          echo "kotlin=${kotlin_version}" >> "$GITHUB_OUTPUT"
+          echo "framework_hash=${framework_hash}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache iOS native dependencies
+        if: steps.ios-build-check.outputs.ios_build_exists != 'true'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.konan/cache
+            ~/.konan/dependencies
+            ~/.konan/kotlin-native-prebuilt-*
+            ~/Library/Caches/CocoaPods
+            iosApp/Pods
+          key: ios-native-${{ runner.os }}-${{ runner.arch }}-${{ steps.ios-cache-metadata.outputs.xcode }}-kotlin-${{ steps.ios-cache-metadata.outputs.kotlin }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties', 'gradle/libs.versions.toml', 'iosApp/Podfile.lock') }}
+          restore-keys: |
+            ios-native-${{ runner.os }}-${{ runner.arch }}-${{ steps.ios-cache-metadata.outputs.xcode }}-kotlin-${{ steps.ios-cache-metadata.outputs.kotlin }}-
+
+      - name: Cache iOS device release framework
+        id: ios-device-framework-cache
+        if: steps.ios-build-check.outputs.ios_build_exists != 'true'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: maincore/build/bin/iosArm64/releaseFramework/maincore.framework
+          key: ios-framework-device-${{ runner.os }}-${{ runner.arch }}-${{ steps.ios-cache-metadata.outputs.xcode }}-kotlin-${{ steps.ios-cache-metadata.outputs.kotlin }}-${{ steps.ios-cache-metadata.outputs.framework_hash }}
+
+      - name: Enable cached iOS device framework
+        if: steps.ios-device-framework-cache.outputs.cache-hit == 'true'
+        run: |
+          set -euo pipefail
+          echo "TUINDICE_IOS_USE_CACHED_FRAMEWORK=1" >> "$GITHUB_ENV"
+
       - name: Set up Java
         if: steps.ios-build-check.outputs.ios_build_exists != 'true'
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1

--- a/.github/workflows/preflight-production-pr.yml
+++ b/.github/workflows/preflight-production-pr.yml
@@ -154,6 +154,52 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
           xcodebuild -version
 
+      - name: Resolve iOS cache metadata
+        id: ios-cache-metadata
+        if: needs.shared-preflight.outputs.ios_tasks != ''
+        run: |
+          set -euo pipefail
+          xcode_cache_id="$(
+            xcodebuild -version \
+              | tr '\n' ' ' \
+              | sed -E 's/[[:space:]]+/ /g; s/[[:space:]]+$//; s/[[:space:]]/-/g'
+          )"
+          kotlin_version="$(
+            sed -n 's/^kotlin = "\(.*\)"/\1/p' gradle/libs.versions.toml | head -n 1
+          )"
+          framework_hash="$(bash ./.github/scripts/ios-framework-cache-key.sh)"
+          echo "xcode=${xcode_cache_id}" >> "$GITHUB_OUTPUT"
+          echo "kotlin=${kotlin_version}" >> "$GITHUB_OUTPUT"
+          echo "framework_hash=${framework_hash}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache iOS native dependencies
+        if: needs.shared-preflight.outputs.ios_tasks != ''
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.konan/cache
+            ~/.konan/dependencies
+            ~/.konan/kotlin-native-prebuilt-*
+            ~/Library/Caches/CocoaPods
+            iosApp/Pods
+          key: ios-native-${{ runner.os }}-${{ runner.arch }}-${{ steps.ios-cache-metadata.outputs.xcode }}-kotlin-${{ steps.ios-cache-metadata.outputs.kotlin }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties', 'gradle/libs.versions.toml', 'iosApp/Podfile.lock') }}
+          restore-keys: |
+            ios-native-${{ runner.os }}-${{ runner.arch }}-${{ steps.ios-cache-metadata.outputs.xcode }}-kotlin-${{ steps.ios-cache-metadata.outputs.kotlin }}-
+
+      - name: Cache iOS device release framework
+        id: ios-device-framework-cache
+        if: contains(needs.shared-preflight.outputs.ios_tasks, 'verifyIosHostBuildDeviceRelease')
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: maincore/build/bin/iosArm64/releaseFramework/maincore.framework
+          key: ios-framework-device-${{ runner.os }}-${{ runner.arch }}-${{ steps.ios-cache-metadata.outputs.xcode }}-kotlin-${{ steps.ios-cache-metadata.outputs.kotlin }}-${{ steps.ios-cache-metadata.outputs.framework_hash }}
+
+      - name: Enable cached iOS device framework
+        if: steps.ios-device-framework-cache.outputs.cache-hit == 'true'
+        run: |
+          set -euo pipefail
+          echo "TUINDICE_IOS_USE_CACHED_FRAMEWORK=1" >> "$GITHUB_ENV"
+
       - name: Set up Java
         if: needs.shared-preflight.outputs.ios_tasks != ''
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
@@ -177,7 +223,7 @@ jobs:
           fi
 
       - name: Materialize Firebase configuration
-        if: contains(needs.shared-preflight.outputs.ios_tasks, 'verifyIosHostBuildRelease')
+        if: contains(needs.shared-preflight.outputs.ios_tasks, 'verifyIosHostBuildDeviceRelease')
         env:
           ANDROID_GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_BASE64 }}
           IOS_GOOGLE_SERVICE_INFO_PLIST_BASE64: ${{ secrets.IOS_GOOGLE_SERVICE_INFO_PLIST_BASE64 }}
@@ -189,18 +235,21 @@ jobs:
         if: needs.shared-preflight.outputs.ios_tasks != ''
         env:
           TUINDICE_IOS_HOST_BUILD: "1"
-          PLATFORM_NAME: iphonesimulator
+          TUINDICE_IOS_HOST_E2E: "1"
+          PLATFORM_NAME: iphoneos
           ARCHS: arm64
-          BUILT_PRODUCTS_DIR: ${{ github.workspace }}/iosApp/.build/ios-host-release/Build/Products/Release-iphonesimulator
+          BUILT_PRODUCTS_DIR: ${{ github.workspace }}/iosApp/.build/ios-host-device-release/Build/Products/Release-iphoneos
           UNLOCALIZED_RESOURCES_FOLDER_PATH: TuIndiceHost.app
+          TUINDICE_IOS_HOST_DEVICE_CODE_SIGNING_ALLOWED: "NO"
         run: |
           set -euo pipefail
           bash ./.github/scripts/run-gradle-with-retry.sh \
             ./gradlew \
+            -I .github/gradle/ios-host-cache.init.gradle.kts \
             --continue \
             --console=plain \
             --max-workers=2 \
-            -Pcompose.ios.resources.platform=iphonesimulator \
+            -Pcompose.ios.resources.platform=iphoneos \
             -Pcompose.ios.resources.archs=arm64 \
             ${{ needs.shared-preflight.outputs.ios_tasks }}
 

--- a/gradle/app-version.properties
+++ b/gradle/app-version.properties
@@ -1,3 +1,3 @@
 versionName=6.1.2
-androidVersionCode=41
-iosBuildNumber=29
+androidVersionCode=42
+iosBuildNumber=30

--- a/iosApp/Config/Version.xcconfig
+++ b/iosApp/Config/Version.xcconfig
@@ -1,3 +1,3 @@
 // Generated from gradle/app-version.properties. Do not edit directly.
 MARKETING_VERSION = 6.1.2
-CURRENT_PROJECT_VERSION = 29
+CURRENT_PROJECT_VERSION = 30

--- a/iosApp/scripts/build-kmp-framework.sh
+++ b/iosApp/scripts/build-kmp-framework.sh
@@ -92,18 +92,71 @@ if [[ "${SKIP_FRAMEWORK_BUILD:-0}" == "1" ]]; then
 	exit 0
 fi
 
+BUILD_TYPE_DIR="$(printf '%s' "$BUILD_TYPE" | tr '[:upper:]' '[:lower:]')"
+
+target_name_for_suffix() {
+	local target_suffix="$1"
+
+	case "$target_suffix" in
+		IosArm64)
+			printf '%s\n' "iosArm64"
+			;;
+		IosSimulatorArm64)
+			printf '%s\n' "iosSimulatorArm64"
+			;;
+		IosX64)
+			printf '%s\n' "iosX64"
+			;;
+		*)
+			echo "Unknown iOS target suffix: $target_suffix" >&2
+			return 1
+			;;
+	esac
+}
+
+framework_binary_for_target_suffix() {
+	local target_suffix="$1"
+	local target_name
+
+	target_name="$(target_name_for_suffix "$target_suffix")"
+	printf '%s/maincore/build/bin/%s/%sFramework/maincore.framework/maincore\n' \
+		"$ROOT_DIR" "$target_name" "$BUILD_TYPE_DIR"
+}
+
+cached_frameworks_available() {
+	local target_suffix
+	local framework_binary
+	local missing=0
+
+	for target_suffix in "${target_suffixes[@]}"; do
+		framework_binary="$(framework_binary_for_target_suffix "$target_suffix")"
+		if [[ ! -f "$framework_binary" ]]; then
+			echo "Cached maincore framework is missing: $framework_binary" >&2
+			missing=1
+		fi
+	done
+
+	[[ "$missing" -eq 0 ]]
+}
+
 mkdir -p "$GRADLE_USER_HOME_DIR"
 prime_local_gradle_wrapper_dist
 export GRADLE_USER_HOME="$GRADLE_USER_HOME_DIR"
-echo "Building maincore framework and syncing Compose resources for iOS"
 declare -a gradle_args=(
 	"-Dorg.gradle.jvmargs=$GRADLE_JVM_ARGS"
 	"--no-configuration-cache"
 )
+used_cached_frameworks=0
 
-for target_suffix in "${target_suffixes[@]}"; do
-	gradle_args+=(":maincore:link${BUILD_TYPE}Framework${target_suffix}")
-done
+if [[ "${TUINDICE_IOS_USE_CACHED_FRAMEWORK:-0}" == "1" ]] && cached_frameworks_available; then
+	echo "Using cached maincore framework and syncing Compose resources for iOS"
+	used_cached_frameworks=1
+else
+	echo "Building maincore framework and syncing Compose resources for iOS"
+	for target_suffix in "${target_suffixes[@]}"; do
+		gradle_args+=(":maincore:link${BUILD_TYPE}Framework${target_suffix}")
+	done
+fi
 
 gradle_args+=(":maincore:syncComposeResourcesForIos")
 
@@ -126,4 +179,8 @@ fi
 
 ./gradlew "${gradle_args[@]}"
 
-write_script_output_stamp "maincore framework linked: ${BUILD_TYPE} ${target_suffixes[*]}"
+if [[ "$used_cached_frameworks" == "1" ]]; then
+	write_script_output_stamp "maincore framework cache used: ${BUILD_TYPE} ${target_suffixes[*]}"
+else
+	write_script_output_stamp "maincore framework linked: ${BUILD_TYPE} ${target_suffixes[*]}"
+fi


### PR DESCRIPTION
## Summary

- Keep `versionName` at `6.1.2`
- Bump Android release code from `41` to `42`
- Bump iOS build number from `29` to `30`
- Sync `iosApp/Config/Version.xcconfig`

## Why

The previous deploy detected an existing Google Play draft for `6.1.2 (41)` and skipped Android upload, while iOS was still attempting build `29`. This restores the intended release identifiers for publishing both platforms.

## Validation

- `bash .github/scripts/validate-app-version.sh`
- `./gradlew --console=plain verifyAppVersionSync`
- `git diff --check`