### PR TITLE
Validate synthetic term creation before submit

### DIFF
--- a/gradle/app-version.properties
+++ b/gradle/app-version.properties
@@ -1,3 +1,3 @@
 versionName=6.1.2
-androidVersionCode=42
-iosBuildNumber=30
+androidVersionCode=43
+iosBuildNumber=31

--- a/gradle/app-version.properties
+++ b/gradle/app-version.properties
@@ -1,3 +1,3 @@
-versionName=6.1.2
+versionName=6.1.3
 androidVersionCode=43
 iosBuildNumber=31

--- a/iosApp/Config/Version.xcconfig
+++ b/iosApp/Config/Version.xcconfig
@@ -1,3 +1,3 @@
 // Generated from gradle/app-version.properties. Do not edit directly.
 MARKETING_VERSION = 6.1.2
-CURRENT_PROJECT_VERSION = 30
+CURRENT_PROJECT_VERSION = 31

--- a/iosApp/Config/Version.xcconfig
+++ b/iosApp/Config/Version.xcconfig
@@ -1,3 +1,3 @@
 // Generated from gradle/app-version.properties. Do not edit directly.
-MARKETING_VERSION = 6.1.2
+MARKETING_VERSION = 6.1.3
 CURRENT_PROJECT_VERSION = 31

--- a/record/src/commonMain/composeResources/values/strings.xml
+++ b/record/src/commonMain/composeResources/values/strings.xml
@@ -60,6 +60,14 @@
 	<string name="create_term_suggested_title">Sugeridas por tu pensum</string>
 	<string name="create_term_no_suggestions">No hay materias sugeridas disponibles.</string>
 	<string name="create_term_search_error">No pudimos actualizar la búsqueda. Mostramos lo disponible en cache.</string>
+	<string name="create_term_error_record_unavailable">No pudimos validar tu informe. Intenta de nuevo.</string>
+	<string name="create_term_error_period_in_past">El trimestre seleccionado ya no está disponible.</string>
+	<string name="create_term_error_term_already_exists">Ya existe un trimestre con ese periodo.</string>
+	<string name="create_term_error_term_must_be_after_latest">El trimestre debe ser posterior al último registrado.</string>
+	<string name="create_term_error_duplicate_subject">Hay materias repetidas en la selección.</string>
+	<string name="create_term_error_subject_already_taken">Una materia seleccionada ya fue aprobada.</string>
+	<string name="create_term_error_subject_already_planned">Una materia seleccionada ya está planificada.</string>
+	<string name="create_term_error_generic">No pudimos crear el trimestre. Revisa la selección.</string>
 	<string name="create_term_subject_available">Disponible</string>
 	<string name="create_term_subject_requirements_met">Requisitos cumplidos</string>
 	<string name="create_term_subject_not_in_pensum">Fuera de tu pensum</string>

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/data/source/SyntheticTermCreationDataSource.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/data/source/SyntheticTermCreationDataSource.kt
@@ -250,7 +250,7 @@ class SyntheticTermCreationDataSource(
 	}
 
 	private fun currentAcademicTermOrder(): Int {
-		val dateTime = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+		val dateTime = Clock.System.now().toLocalDateTime(TimeZone.of(AcademicCalendarTimeZoneId))
 		return dateTime.year * 10 + periodForMonth(dateTime.month.ordinal + 1).sequence
 	}
 
@@ -500,4 +500,5 @@ private const val SearchLimit = 20
 private const val FuturePeriodCount = 20
 private const val SuggestedSubjectLimit = 8
 private const val NodeTypeCourse = "COURSE"
+private const val AcademicCalendarTimeZoneId = "America/Caracas"
 private val RealSubjectCodeRegex = Regex("^([A-Z]{2}\\d{4}|[A-Z]{3}\\d{3})$")

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/exception/SyntheticTermValidationException.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/exception/SyntheticTermValidationException.kt
@@ -1,0 +1,7 @@
+package com.gdavidpb.tuindice.record.domain.exception
+
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermValidationError
+
+class SyntheticTermValidationException(
+	val reason: SyntheticTermValidationError
+) : IllegalArgumentException(reason.name)

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/model/SyntheticTermValidationError.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/model/SyntheticTermValidationError.kt
@@ -1,0 +1,12 @@
+package com.gdavidpb.tuindice.record.domain.model
+
+enum class SyntheticTermValidationError {
+	RECORD_UNAVAILABLE,
+	TERM_NOT_FOUND,
+	PERIOD_IN_PAST,
+	TERM_ALREADY_EXISTS,
+	TERM_MUST_BE_AFTER_LATEST,
+	DUPLICATE_SUBJECT,
+	SUBJECT_ALREADY_TAKEN,
+	SUBJECT_ALREADY_PLANNED
+}

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/CreateSyntheticTermUseCase.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/CreateSyntheticTermUseCase.kt
@@ -4,7 +4,9 @@ import com.gdavidpb.tuindice.academiccore.domain.model.AttemptOutcome
 import com.gdavidpb.tuindice.academiccore.domain.model.AttemptScore
 import com.gdavidpb.tuindice.base.domain.repository.ReportingRepository
 import com.gdavidpb.tuindice.base.domain.usecase.base.FlowUseCase
+import com.gdavidpb.tuindice.record.domain.exception.SyntheticTermValidationException
 import com.gdavidpb.tuindice.record.domain.model.SyntheticTermCreationCommand
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermValidationError
 import com.gdavidpb.tuindice.record.domain.repository.AcademicRecordRepository
 import com.gdavidpb.tuindice.record.domain.usecase.error.RecordUseCaseError
 import com.gdavidpb.tuindice.record.domain.usecase.exceptionhandler.RecordExceptionHandler
@@ -20,6 +22,13 @@ class CreateSyntheticTermUseCase(
 	reportingRepository = reportingRepository
 ) {
 	override suspend fun executeOnBackground(params: CreateSyntheticTermParams): Flow<Unit> {
+		val record = repository.getAcademicRecord()
+			?: throw SyntheticTermValidationException(SyntheticTermValidationError.RECORD_UNAVAILABLE)
+		SyntheticTermCommandValidator.validate(
+			record = record,
+			params = params
+		)
+
 		val termId = params.period.termKey
 		repository.addSyntheticTerm(
 			SyntheticTermCreationCommand(

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/SyntheticTermCommandValidator.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/SyntheticTermCommandValidator.kt
@@ -1,0 +1,115 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.gdavidpb.tuindice.record.domain.usecase
+
+import com.gdavidpb.tuindice.academiccore.domain.model.AcademicRecord
+import com.gdavidpb.tuindice.academiccore.domain.model.AcademicTerm
+import com.gdavidpb.tuindice.academiccore.domain.model.AcademicTermPeriod
+import com.gdavidpb.tuindice.academiccore.domain.model.AttemptOutcome
+import com.gdavidpb.tuindice.academiccore.domain.model.isCurrent
+import com.gdavidpb.tuindice.academiccore.domain.model.isHistorical
+import com.gdavidpb.tuindice.academiccore.domain.model.isSynthetic
+import com.gdavidpb.tuindice.record.domain.exception.SyntheticTermValidationException
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermPeriodOption
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermSubject
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermValidationError
+import com.gdavidpb.tuindice.record.domain.usecase.param.CreateSyntheticTermParams
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+internal object SyntheticTermCommandValidator {
+	fun validate(
+		record: AcademicRecord,
+		params: CreateSyntheticTermParams
+	) {
+		val editingTerm = params.editingTermId?.let { editingTermId ->
+			record.terms.firstOrNull { term -> term.id == editingTermId && term.kind.isSynthetic }
+				?: throw SyntheticTermValidationException(SyntheticTermValidationError.TERM_NOT_FOUND)
+		}
+		val otherTerms = if (editingTerm == null) {
+			record.terms
+		} else {
+			record.terms.filterNot { term -> term.id == editingTerm.id }
+		}
+		val keepsSameTermKey = editingTerm?.termKey == params.period.termKey
+
+		validatePeriod(
+			otherTerms = otherTerms,
+			period = params.period,
+			keepsSameTermKey = keepsSameTermKey
+		)
+		validateSubjects(
+			otherTerms = otherTerms,
+			subjects = params.subjects
+		)
+	}
+
+	private fun validatePeriod(
+		otherTerms: List<AcademicTerm>,
+		period: SyntheticTermPeriodOption,
+		keepsSameTermKey: Boolean
+	) {
+		if (otherTerms.any { term -> term.termKey == period.termKey }) {
+			throw SyntheticTermValidationException(SyntheticTermValidationError.TERM_ALREADY_EXISTS)
+		}
+		if (!keepsSameTermKey && period.termOrder < currentAcademicTermOrder()) {
+			throw SyntheticTermValidationException(SyntheticTermValidationError.PERIOD_IN_PAST)
+		}
+		if (!keepsSameTermKey && otherTerms.maxOfOrNull(AcademicTerm::termOrder)?.let { latestOrder ->
+				period.termOrder <= latestOrder
+			} == true
+		) {
+			throw SyntheticTermValidationException(SyntheticTermValidationError.TERM_MUST_BE_AFTER_LATEST)
+		}
+	}
+
+	private fun validateSubjects(
+		otherTerms: List<AcademicTerm>,
+		subjects: List<SyntheticTermSubject>
+	) {
+		val subjectCodes = subjects.map { subject -> subject.subjectCode.trim().uppercase() }
+		if (subjectCodes.distinct().size != subjectCodes.size) {
+			throw SyntheticTermValidationException(SyntheticTermValidationError.DUPLICATE_SUBJECT)
+		}
+
+		val plannedSubjectCodes = otherTerms
+			.filter { term -> term.kind.isSynthetic }
+			.flatMap(AcademicTerm::attempts)
+			.map { attempt -> attempt.subjectCode.uppercase() }
+			.toSet()
+		val takenSubjectCodes = otherTerms
+			.filter { term -> term.kind.isHistorical || term.kind.isCurrent }
+			.flatMap { term ->
+				term.attempts.filter { attempt ->
+					attempt.academicOutcome == AttemptOutcome.APPROVED
+				}
+			}
+			.map { attempt -> attempt.subjectCode.uppercase() }
+			.toSet()
+
+		when {
+			subjectCodes.any { subjectCode -> subjectCode in takenSubjectCodes } ->
+				throw SyntheticTermValidationException(SyntheticTermValidationError.SUBJECT_ALREADY_TAKEN)
+			subjectCodes.any { subjectCode -> subjectCode in plannedSubjectCodes } ->
+				throw SyntheticTermValidationException(SyntheticTermValidationError.SUBJECT_ALREADY_PLANNED)
+		}
+	}
+
+	private fun currentAcademicTermOrder(): Int {
+		val dateTime = Clock.System.now().toLocalDateTime(TimeZone.of(AcademicCalendarTimeZoneId))
+		return dateTime.year * 10 + periodForMonth(dateTime.month.ordinal + 1).sequence
+	}
+
+	private fun periodForMonth(month: Int): AcademicTermPeriod {
+		return when (month) {
+			in 1..3 -> AcademicTermPeriod.JAN_MAR
+			in 4..6 -> AcademicTermPeriod.APR_JUL
+			in 7..8 -> AcademicTermPeriod.JUL_AUG
+			else -> AcademicTermPeriod.SEP_DEC
+		}
+	}
+}
+
+private const val AcademicCalendarTimeZoneId = "America/Caracas"

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/UpdateSyntheticTermUseCase.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/UpdateSyntheticTermUseCase.kt
@@ -4,7 +4,9 @@ import com.gdavidpb.tuindice.academiccore.domain.model.AttemptOutcome
 import com.gdavidpb.tuindice.academiccore.domain.model.AttemptScore
 import com.gdavidpb.tuindice.base.domain.repository.ReportingRepository
 import com.gdavidpb.tuindice.base.domain.usecase.base.FlowUseCase
+import com.gdavidpb.tuindice.record.domain.exception.SyntheticTermValidationException
 import com.gdavidpb.tuindice.record.domain.model.SyntheticTermUpdateCommand
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermValidationError
 import com.gdavidpb.tuindice.record.domain.repository.AcademicRecordRepository
 import com.gdavidpb.tuindice.record.domain.usecase.error.RecordUseCaseError
 import com.gdavidpb.tuindice.record.domain.usecase.exceptionhandler.RecordExceptionHandler
@@ -22,6 +24,13 @@ class UpdateSyntheticTermUseCase(
 	override suspend fun executeOnBackground(params: CreateSyntheticTermParams): Flow<Unit> {
 		val targetTermId = requireNotNull(params.editingTermId)
 		val targetTermKey = requireNotNull(params.editingTermKey)
+		val record = repository.getAcademicRecord()
+			?: throw SyntheticTermValidationException(SyntheticTermValidationError.RECORD_UNAVAILABLE)
+		SyntheticTermCommandValidator.validate(
+			record = record,
+			params = params
+		)
+
 		val keepsTermIdentity = params.period.termKey == targetTermKey
 		val termId = if (keepsTermIdentity) targetTermId else params.period.termKey
 

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/error/RecordUseCaseError.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/error/RecordUseCaseError.kt
@@ -1,10 +1,14 @@
 package com.gdavidpb.tuindice.record.domain.usecase.error
 
 import com.gdavidpb.tuindice.base.domain.usecase.base.UseCaseError
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermValidationError
 
 sealed interface RecordUseCaseError : UseCaseError {
 	data object Unauthorized : RecordUseCaseError
 	data object Timeout : RecordUseCaseError
 	data object Unavailable : RecordUseCaseError
 	data object NoConnection : RecordUseCaseError
+	data class SyntheticTermValidation(
+		val reason: SyntheticTermValidationError
+	) : RecordUseCaseError
 }

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/exceptionhandler/RecordExceptionHandler.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/exceptionhandler/RecordExceptionHandler.kt
@@ -5,11 +5,14 @@ import com.gdavidpb.tuindice.base.utils.extension.isConnection
 import com.gdavidpb.tuindice.base.utils.extension.isTimeout
 import com.gdavidpb.tuindice.base.utils.extension.isUnauthorized
 import com.gdavidpb.tuindice.base.utils.extension.isUnavailable
+import com.gdavidpb.tuindice.record.domain.exception.SyntheticTermValidationException
 import com.gdavidpb.tuindice.record.domain.usecase.error.RecordUseCaseError
 
 class RecordExceptionHandler : ExceptionHandler<RecordUseCaseError>() {
 	override fun parseException(throwable: Throwable): RecordUseCaseError? {
 		return when {
+			throwable is SyntheticTermValidationException ->
+				RecordUseCaseError.SyntheticTermValidation(throwable.reason)
 			throwable.isUnauthorized() -> RecordUseCaseError.Unauthorized
 			throwable.isTimeout() -> RecordUseCaseError.Timeout
 			throwable.isUnavailable() -> RecordUseCaseError.Unavailable

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/presentation/action/CreateSyntheticTermActionProcessor.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/presentation/action/CreateSyntheticTermActionProcessor.kt
@@ -3,12 +3,24 @@ package com.gdavidpb.tuindice.record.presentation.action
 import com.gdavidpb.tuindice.base.domain.usecase.base.UseCaseState
 import com.gdavidpb.tuindice.base.presentation.Mutation
 import com.gdavidpb.tuindice.base.presentation.action.ActionProcessor
+import com.gdavidpb.tuindice.base.presentation.model.UiText
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermValidationError
 import com.gdavidpb.tuindice.record.domain.usecase.CreateSyntheticTermUseCase
 import com.gdavidpb.tuindice.record.domain.usecase.UpdateSyntheticTermUseCase
+import com.gdavidpb.tuindice.record.domain.usecase.error.RecordUseCaseError
 import com.gdavidpb.tuindice.record.domain.usecase.param.CreateSyntheticTermParams
 import com.gdavidpb.tuindice.record.presentation.contract.CreateSyntheticTerm
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import tuindice.record.generated.resources.Res
+import tuindice.record.generated.resources.create_term_error_duplicate_subject
+import tuindice.record.generated.resources.create_term_error_generic
+import tuindice.record.generated.resources.create_term_error_period_in_past
+import tuindice.record.generated.resources.create_term_error_record_unavailable
+import tuindice.record.generated.resources.create_term_error_subject_already_planned
+import tuindice.record.generated.resources.create_term_error_subject_already_taken
+import tuindice.record.generated.resources.create_term_error_term_already_exists
+import tuindice.record.generated.resources.create_term_error_term_must_be_after_latest
 
 class CreateSyntheticTermActionProcessor(
 	private val createSyntheticTermUseCase: CreateSyntheticTermUseCase,
@@ -40,14 +52,20 @@ class CreateSyntheticTermActionProcessor(
 					is UseCaseState.Loading ->
 						emit(
 							suspend { state: CreateSyntheticTerm.State ->
-								state.copy(isSubmitting = true)
+								state.copy(
+									isSubmitting = true,
+									submitError = UiText.Empty
+								)
 							}
 						)
 
 					is UseCaseState.Data -> {
 						emit(
 							suspend { state: CreateSyntheticTerm.State ->
-								state.copy(isSubmitting = false)
+								state.copy(
+									isSubmitting = false,
+									submitError = UiText.Empty
+								)
 							}
 						)
 						sideEffect(CreateSyntheticTerm.Effect.NavigateBack)
@@ -56,11 +74,40 @@ class CreateSyntheticTermActionProcessor(
 					is UseCaseState.Error ->
 						emit(
 							suspend { state: CreateSyntheticTerm.State ->
-								state.copy(isSubmitting = false)
+								state.copy(
+									isSubmitting = false,
+									submitError = useCaseState.error.toSubmitErrorText()
+								)
 							}
 						)
 				}
 			}
 		}
+	}
+}
+
+private fun RecordUseCaseError?.toSubmitErrorText(): UiText {
+	return when (this) {
+		is RecordUseCaseError.SyntheticTermValidation -> UiText.Resource(
+			when (reason) {
+				SyntheticTermValidationError.RECORD_UNAVAILABLE,
+				SyntheticTermValidationError.TERM_NOT_FOUND,
+				-> Res.string.create_term_error_record_unavailable
+
+				SyntheticTermValidationError.PERIOD_IN_PAST -> Res.string.create_term_error_period_in_past
+				SyntheticTermValidationError.TERM_ALREADY_EXISTS -> Res.string.create_term_error_term_already_exists
+				SyntheticTermValidationError.TERM_MUST_BE_AFTER_LATEST -> Res.string.create_term_error_term_must_be_after_latest
+				SyntheticTermValidationError.DUPLICATE_SUBJECT -> Res.string.create_term_error_duplicate_subject
+				SyntheticTermValidationError.SUBJECT_ALREADY_TAKEN -> Res.string.create_term_error_subject_already_taken
+				SyntheticTermValidationError.SUBJECT_ALREADY_PLANNED -> Res.string.create_term_error_subject_already_planned
+			}
+		)
+
+		RecordUseCaseError.NoConnection,
+		RecordUseCaseError.Timeout,
+		RecordUseCaseError.Unauthorized,
+		RecordUseCaseError.Unavailable,
+		null,
+		-> UiText.Resource(Res.string.create_term_error_generic)
 	}
 }

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/presentation/action/ObserveCreateSyntheticTermActionProcessor.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/presentation/action/ObserveCreateSyntheticTermActionProcessor.kt
@@ -4,6 +4,7 @@ import com.gdavidpb.tuindice.base.domain.usecase.base.UseCaseState
 import com.gdavidpb.tuindice.base.presentation.Mutation
 import com.gdavidpb.tuindice.base.presentation.action.ActionProcessor
 import com.gdavidpb.tuindice.base.domain.utils.SubjectCatalogSearchNormalizer
+import com.gdavidpb.tuindice.base.presentation.model.UiText
 import com.gdavidpb.tuindice.record.domain.model.SyntheticTermSubject
 import com.gdavidpb.tuindice.record.domain.usecase.LoadSyntheticTermPreviewUseCase
 import com.gdavidpb.tuindice.record.domain.usecase.ObserveSyntheticTermCreationUseCase
@@ -80,6 +81,7 @@ class ObserveCreateSyntheticTermActionProcessor(
 							selectedSubjects = useCaseState.value.selectedSubjects,
 							suggestedSubjects = useCaseState.value.suggestedSubjects,
 							searchResults = useCaseState.value.searchResults,
+							submitError = UiText.Empty,
 							hasSearchError = if (useCaseState.value.searchResults.isNotEmpty()) false else state.hasSearchError
 						)
 					}

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/presentation/contract/CreateSyntheticTerm.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/presentation/contract/CreateSyntheticTerm.kt
@@ -33,7 +33,8 @@ object CreateSyntheticTerm {
 		val hasLoadPreviewError: Boolean = false,
 		val isRefreshingSearch: Boolean = false,
 		val hasSearchError: Boolean = false,
-		val isSubmitting: Boolean = false
+		val isSubmitting: Boolean = false,
+		val submitError: UiText = UiText.Empty
 	) : ViewState() {
 		val canSubmit: Boolean
 			get() = selectedPeriod != null && selectedSubjects.isNotEmpty() && !isSubmitting

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/ui/RecordUiTags.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/ui/RecordUiTags.kt
@@ -23,6 +23,7 @@ object RecordUiTags {
 	const val CreateSyntheticTermSearchClearButton = "record_create_synthetic_term_search_clear_button"
 	const val CreateSyntheticTermSearchResultsTitle = "record_create_synthetic_term_search_results_title"
 	const val CreateSyntheticTermSubmitButton = "record_create_synthetic_term_submit_button"
+	const val CreateSyntheticTermSubmitError = "record_create_synthetic_term_submit_error"
 	const val CreateSyntheticTermSubmitProgress = "record_create_synthetic_term_submit_progress"
 	const val CreateSyntheticTermTakenSubjectsToggle = "record_create_synthetic_term_taken_subjects_toggle"
 	const val CreateSyntheticTermSuggestedTab = "record_create_synthetic_term_suggested_tab"

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/ui/screen/CreateSyntheticTermScreen.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/ui/screen/CreateSyntheticTermScreen.kt
@@ -324,6 +324,7 @@ fun CreateSyntheticTermScreen(
 			canSubmit = state.canSubmit,
 			isEditing = state.isEditing,
 			isSubmitting = state.isSubmitting,
+			submitError = state.submitError,
 			onCreateClick = onCreateClick,
 			modifier = Modifier
 				.align(Alignment.BottomCenter)

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/ui/view/CreateTermSubmitBarView.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/ui/view/CreateTermSubmitBarView.kt
@@ -2,6 +2,7 @@ package com.gdavidpb.tuindice.record.ui.view
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -21,6 +22,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.gdavidpb.tuindice.base.presentation.model.UiText
+import com.gdavidpb.tuindice.base.presentation.model.asString
 import com.gdavidpb.tuindice.record.ui.RecordUiTags
 import org.jetbrains.compose.resources.stringResource
 import tuindice.record.generated.resources.Res
@@ -34,6 +37,7 @@ fun CreateTermSubmitBar(
 	canSubmit: Boolean,
 	isEditing: Boolean,
 	isSubmitting: Boolean,
+	submitError: UiText,
 	onCreateClick: () -> Unit,
 	modifier: Modifier = Modifier
 ) {
@@ -46,48 +50,63 @@ fun CreateTermSubmitBar(
 		),
 		tonalElevation = 6.dp
 	) {
-		Row(
+		Column(
 			modifier = Modifier
 				.fillMaxWidth()
 				.padding(horizontal = 20.dp, vertical = 14.dp),
-			horizontalArrangement = Arrangement.spacedBy(16.dp),
-			verticalAlignment = Alignment.CenterVertically
 		) {
-			Text(
-				modifier = Modifier
-					.weight(1f)
-					.widthIn(min = 148.dp),
-				text = stringResource(Res.string.create_term_selected_count, selectedCount),
-				style = MaterialTheme.typography.bodyMedium,
-				color = MaterialTheme.colorScheme.onSurfaceVariant,
-				maxLines = 1,
-				overflow = TextOverflow.Ellipsis
-			)
-			Button(
-				modifier = Modifier
-					.width(162.dp)
-					.height(52.dp)
-					.testTag(RecordUiTags.CreateSyntheticTermSubmitButton),
-				enabled = canSubmit,
-				onClick = onCreateClick,
-				shape = RoundedCornerShape(999.dp)
+			if (submitError != UiText.Empty) {
+				Text(
+					modifier = Modifier
+						.fillMaxWidth()
+						.padding(bottom = 10.dp)
+						.testTag(RecordUiTags.CreateSyntheticTermSubmitError),
+					text = submitError.asString(),
+					style = MaterialTheme.typography.bodyMedium,
+					color = MaterialTheme.colorScheme.error
+				)
+			}
+			Row(
+				modifier = Modifier.fillMaxWidth(),
+				horizontalArrangement = Arrangement.spacedBy(16.dp),
+				verticalAlignment = Alignment.CenterVertically
 			) {
-				if (isSubmitting) {
-					CircularProgressIndicator(
-						modifier = Modifier
-							.testTag(RecordUiTags.CreateSyntheticTermSubmitProgress)
-							.size(20.dp),
-						color = MaterialTheme.colorScheme.onSurfaceVariant,
-						strokeWidth = 2.dp
-					)
-				} else {
-					Text(
-						text = stringResource(
-							if (isEditing) Res.string.edit_term_button else Res.string.create_term_button
-						),
-						maxLines = 1,
-						overflow = TextOverflow.Ellipsis
-					)
+				Text(
+					modifier = Modifier
+						.weight(1f)
+						.widthIn(min = 148.dp),
+					text = stringResource(Res.string.create_term_selected_count, selectedCount),
+					style = MaterialTheme.typography.bodyMedium,
+					color = MaterialTheme.colorScheme.onSurfaceVariant,
+					maxLines = 1,
+					overflow = TextOverflow.Ellipsis
+				)
+				Button(
+					modifier = Modifier
+						.width(162.dp)
+						.height(52.dp)
+						.testTag(RecordUiTags.CreateSyntheticTermSubmitButton),
+					enabled = canSubmit,
+					onClick = onCreateClick,
+					shape = RoundedCornerShape(999.dp)
+				) {
+					if (isSubmitting) {
+						CircularProgressIndicator(
+							modifier = Modifier
+								.testTag(RecordUiTags.CreateSyntheticTermSubmitProgress)
+								.size(20.dp),
+							color = MaterialTheme.colorScheme.onSurfaceVariant,
+							strokeWidth = 2.dp
+						)
+					} else {
+						Text(
+							text = stringResource(
+								if (isEditing) Res.string.edit_term_button else Res.string.create_term_button
+							),
+							maxLines = 1,
+							overflow = TextOverflow.Ellipsis
+						)
+					}
 				}
 			}
 		}

--- a/record/src/commonTest/kotlin/com/gdavidpb/tuindice/record/domain/usecase/CreateSyntheticTermUseCaseTest.kt
+++ b/record/src/commonTest/kotlin/com/gdavidpb/tuindice/record/domain/usecase/CreateSyntheticTermUseCaseTest.kt
@@ -1,0 +1,210 @@
+package com.gdavidpb.tuindice.record.domain.usecase
+
+import com.gdavidpb.tuindice.academiccore.domain.model.AcademicAttempt
+import com.gdavidpb.tuindice.academiccore.domain.model.AcademicRecord
+import com.gdavidpb.tuindice.academiccore.domain.model.AcademicTerm
+import com.gdavidpb.tuindice.academiccore.domain.model.AcademicTermPeriod
+import com.gdavidpb.tuindice.academiccore.domain.model.AttemptOutcome
+import com.gdavidpb.tuindice.academiccore.domain.model.AttemptScore
+import com.gdavidpb.tuindice.academiccore.domain.model.TermKind
+import com.gdavidpb.tuindice.base.domain.usecase.base.UseCaseState
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermCreationCommand
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermPeriodOption
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermSubject
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermUpdateCommand
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermValidationError
+import com.gdavidpb.tuindice.record.domain.repository.AcademicRecordRepository
+import com.gdavidpb.tuindice.record.domain.usecase.error.RecordUseCaseError
+import com.gdavidpb.tuindice.record.domain.usecase.exceptionhandler.RecordExceptionHandler
+import com.gdavidpb.tuindice.record.domain.usecase.param.CreateSyntheticTermParams
+import com.gdavidpb.tuindice.testkit.base.repository.RecordingReportingRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class CreateSyntheticTermUseCaseTest {
+	@Test
+	fun execute_allowsFailedAndRetiredHistoricalSubjects() = runTest {
+		val repository = RecordingCreateAcademicRecordRepository(
+			record = AcademicRecord(
+				id = "record",
+				terms = listOf(
+					academicTerm(
+						id = "historical",
+						kind = TermKind.HISTORICAL,
+						attempts = listOf(
+							academicAttempt(subjectCode = "MA1112", outcome = AttemptOutcome.FAILED),
+							academicAttempt(subjectCode = "FS1111", outcome = AttemptOutcome.RETIRED)
+						)
+					)
+				)
+			)
+		)
+		val useCase = createUseCase(repository)
+
+		useCase.execute(
+			createParams(
+				subjects = listOf(
+					syntheticSubject("MA1112"),
+					syntheticSubject("FS1111")
+				)
+			)
+		).toList()
+
+		assertEquals(
+			listOf(listOf("MA1112", "FS1111")),
+			repository.addedTerms.map { command ->
+				command.attempts.map(SyntheticTermCreationCommand.SyntheticAttemptSeed::subjectCode)
+			}
+		)
+	}
+
+	@Test
+	fun execute_rejectsApprovedHistoricalSubjectsBeforeSubmittingMutation() = runTest {
+		val repository = RecordingCreateAcademicRecordRepository(
+			record = AcademicRecord(
+				id = "record",
+				terms = listOf(
+					academicTerm(
+						id = "historical",
+						kind = TermKind.HISTORICAL,
+						attempts = listOf(
+							academicAttempt(subjectCode = "MA1112", outcome = AttemptOutcome.APPROVED)
+						)
+					)
+				)
+			)
+		)
+		val states = createUseCase(repository)
+			.execute(createParams(subjects = listOf(syntheticSubject("MA1112"))))
+			.toList()
+
+		val errorState = assertIs<UseCaseState.Error<Unit, RecordUseCaseError>>(states.last())
+		val error = assertIs<RecordUseCaseError.SyntheticTermValidation>(errorState.error)
+		assertEquals(SyntheticTermValidationError.SUBJECT_ALREADY_TAKEN, error.reason)
+		assertEquals(emptyList(), repository.addedTerms)
+	}
+
+	@Test
+	fun execute_rejectsExistingTermPeriodBeforeSubmittingMutation() = runTest {
+		val repository = RecordingCreateAcademicRecordRepository(
+			record = AcademicRecord(
+				id = "record",
+				terms = listOf(
+					academicTerm(
+						id = "existing",
+						kind = TermKind.SYNTHETIC,
+						periodYear = 9999,
+						periodCode = AcademicTermPeriod.JAN_MAR
+					)
+				)
+			)
+		)
+		val states = createUseCase(repository)
+			.execute(createParams(subjects = listOf(syntheticSubject("MA1112"))))
+			.toList()
+
+		val errorState = assertIs<UseCaseState.Error<Unit, RecordUseCaseError>>(states.last())
+		val error = assertIs<RecordUseCaseError.SyntheticTermValidation>(errorState.error)
+		assertEquals(SyntheticTermValidationError.TERM_ALREADY_EXISTS, error.reason)
+		assertEquals(emptyList(), repository.addedTerms)
+	}
+
+	private fun createUseCase(repository: AcademicRecordRepository): CreateSyntheticTermUseCase {
+		return CreateSyntheticTermUseCase(
+			repository = repository,
+			reportingRepository = RecordingReportingRepository(),
+			exceptionHandler = RecordExceptionHandler()
+		)
+	}
+}
+
+private class RecordingCreateAcademicRecordRepository(
+	private val record: AcademicRecord?
+) : AcademicRecordRepository {
+	val addedTerms = mutableListOf<SyntheticTermCreationCommand>()
+
+	override suspend fun observeAcademicRecordFlow(): Flow<AcademicRecord> = emptyFlow()
+
+	override suspend fun observeHasSyncedRecordFlow(): Flow<Boolean> = emptyFlow()
+
+	override suspend fun getAcademicRecord(): AcademicRecord? = record
+
+	override suspend fun updateAcademicRecord() = Unit
+
+	override suspend fun drainPendingMutations() = Unit
+
+	override suspend fun upsertAttemptOverride(
+		attemptId: String,
+		score: AttemptScore?,
+		outcome: AttemptOutcome?,
+		commit: Boolean
+	) = Unit
+
+	override suspend fun deleteAttemptOverride(attemptId: String) = Unit
+
+	override suspend fun addSyntheticTerm(command: SyntheticTermCreationCommand) {
+		addedTerms += command
+	}
+
+	override suspend fun updateSyntheticTerm(command: SyntheticTermUpdateCommand) = Unit
+
+	override suspend fun deleteSyntheticTerm(termId: String) = Unit
+}
+
+private fun createParams(
+	subjects: List<SyntheticTermSubject>,
+	periodYear: Int = 9999,
+	periodCode: AcademicTermPeriod = AcademicTermPeriod.JAN_MAR
+): CreateSyntheticTermParams {
+	return CreateSyntheticTermParams(
+		editingTermId = null,
+		editingTermKey = null,
+		period = SyntheticTermPeriodOption(
+			periodYear = periodYear,
+			periodCode = periodCode
+		),
+		subjects = subjects
+	)
+}
+
+private fun academicTerm(
+	id: String,
+	kind: TermKind,
+	periodYear: Int = 2024,
+	periodCode: AcademicTermPeriod = AcademicTermPeriod.JAN_MAR,
+	attempts: List<AcademicAttempt> = emptyList()
+): AcademicTerm {
+	return AcademicTerm(
+		id = id,
+		periodYear = periodYear,
+		periodCode = periodCode,
+		kind = kind,
+		attempts = attempts
+	)
+}
+
+private fun academicAttempt(
+	subjectCode: String,
+	outcome: AttemptOutcome
+): AcademicAttempt {
+	return AcademicAttempt(
+		id = "attempt-$subjectCode",
+		subjectCode = subjectCode,
+		subjectName = subjectCode,
+		credits = 4,
+		academicOutcome = outcome
+	)
+}
+
+private fun syntheticSubject(subjectCode: String): SyntheticTermSubject {
+	return SyntheticTermSubject(
+		subjectCode = subjectCode,
+		name = subjectCode,
+		credits = 4
+	)
+}

--- a/record/src/commonTest/kotlin/com/gdavidpb/tuindice/record/presentation/action/CreateSyntheticTermActionProcessorTest.kt
+++ b/record/src/commonTest/kotlin/com/gdavidpb/tuindice/record/presentation/action/CreateSyntheticTermActionProcessorTest.kt
@@ -1,0 +1,138 @@
+package com.gdavidpb.tuindice.record.presentation.action
+
+import com.gdavidpb.tuindice.academiccore.domain.model.AcademicAttempt
+import com.gdavidpb.tuindice.academiccore.domain.model.AcademicRecord
+import com.gdavidpb.tuindice.academiccore.domain.model.AcademicTerm
+import com.gdavidpb.tuindice.academiccore.domain.model.AcademicTermPeriod
+import com.gdavidpb.tuindice.academiccore.domain.model.AttemptOutcome
+import com.gdavidpb.tuindice.academiccore.domain.model.AttemptScore
+import com.gdavidpb.tuindice.academiccore.domain.model.TermKind
+import com.gdavidpb.tuindice.base.presentation.model.UiText
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermCreationCommand
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermPeriodOption
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermSubject
+import com.gdavidpb.tuindice.record.domain.model.SyntheticTermUpdateCommand
+import com.gdavidpb.tuindice.record.domain.repository.AcademicRecordRepository
+import com.gdavidpb.tuindice.record.domain.usecase.CreateSyntheticTermUseCase
+import com.gdavidpb.tuindice.record.domain.usecase.UpdateSyntheticTermUseCase
+import com.gdavidpb.tuindice.record.domain.usecase.exceptionhandler.RecordExceptionHandler
+import com.gdavidpb.tuindice.record.presentation.contract.CreateSyntheticTerm
+import com.gdavidpb.tuindice.testkit.base.repository.RecordingReportingRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import tuindice.record.generated.resources.Res
+import tuindice.record.generated.resources.create_term_error_subject_already_taken
+
+class CreateSyntheticTermActionProcessorTest {
+	@Test
+	fun process_whenLocalValidationFails_keepsUserInCreateFlowAndShowsSubmitError() = runTest {
+		val repository = RecordingAcademicRecordRepository(
+			record = AcademicRecord(
+				id = "record",
+				terms = listOf(
+					AcademicTerm(
+						id = "historical",
+						periodYear = 2024,
+						periodCode = AcademicTermPeriod.JAN_MAR,
+						kind = TermKind.HISTORICAL,
+						attempts = listOf(
+							AcademicAttempt(
+								id = "attempt-ma1112",
+								subjectCode = "MA1112",
+								subjectName = "Matemáticas II",
+								credits = 4,
+								academicOutcome = AttemptOutcome.APPROVED
+							)
+						)
+					)
+				)
+			)
+		)
+		val effects = mutableListOf<CreateSyntheticTerm.Effect>()
+		val mutations = processor(repository).process(
+			action = CreateSyntheticTerm.Action.CreateTerm(
+				editingTermId = null,
+				editingTermKey = null,
+				period = SyntheticTermPeriodOption(
+					periodYear = 9999,
+					periodCode = AcademicTermPeriod.JAN_MAR
+				),
+				subjects = listOf(
+					SyntheticTermSubject(
+						subjectCode = "MA1112",
+						name = "Matemáticas II",
+						credits = 4
+					)
+				)
+			),
+			sideEffect = { effect -> effects += effect }
+		).toList()
+
+		var state = CreateSyntheticTerm.State()
+		for (mutation in mutations) {
+			state = mutation(state)
+		}
+
+		assertEquals(
+			UiText.Resource(Res.string.create_term_error_subject_already_taken),
+			state.submitError
+		)
+		assertEquals(emptyList(), repository.addedTerms)
+		assertTrue(effects.isEmpty())
+	}
+
+	private fun processor(repository: AcademicRecordRepository): CreateSyntheticTermActionProcessor {
+		val reportingRepository = RecordingReportingRepository()
+		val exceptionHandler = RecordExceptionHandler()
+		return CreateSyntheticTermActionProcessor(
+			createSyntheticTermUseCase = CreateSyntheticTermUseCase(
+				repository = repository,
+				reportingRepository = reportingRepository,
+				exceptionHandler = exceptionHandler
+			),
+			updateSyntheticTermUseCase = UpdateSyntheticTermUseCase(
+				repository = repository,
+				reportingRepository = reportingRepository,
+				exceptionHandler = exceptionHandler
+			)
+		)
+	}
+}
+
+private class RecordingAcademicRecordRepository(
+	private val record: AcademicRecord?
+) : AcademicRecordRepository {
+	val addedTerms = mutableListOf<SyntheticTermCreationCommand>()
+
+	override suspend fun observeAcademicRecordFlow(): Flow<AcademicRecord> = emptyFlow()
+
+	override suspend fun observeHasSyncedRecordFlow(): Flow<Boolean> = emptyFlow()
+
+	override suspend fun getAcademicRecord(): AcademicRecord? = record
+
+	override suspend fun updateAcademicRecord() = Unit
+
+	override suspend fun drainPendingMutations() = Unit
+
+	override suspend fun upsertAttemptOverride(
+		attemptId: String,
+		score: AttemptScore?,
+		outcome: AttemptOutcome?,
+		commit: Boolean
+	) = Unit
+
+	override suspend fun deleteAttemptOverride(attemptId: String) = Unit
+
+	override suspend fun addSyntheticTerm(command: SyntheticTermCreationCommand) {
+		addedTerms += command
+	}
+
+	override suspend fun updateSyntheticTerm(command: SyntheticTermUpdateCommand) = Unit
+
+	override suspend fun deleteSyntheticTerm(termId: String) = Unit
+}


### PR DESCRIPTION
## Summary
- Validate synthetic term commands locally before submitting optimistic mutations
- Surface synthetic term validation errors inline in the create flow
- Align create/update validation with backend rules for approved/current/synthetic subjects
- Bump Android/iOS build numbers for release validation

## Tests
- ./gradlew --console=plain :record:compileAndroidMain :record:compileKotlinIosSimulatorArm64 :record:allTests
- local-e2e/android/record-suite: success
- local-e2e/ios/record-suite: success