### PR TITLE
Fix record and evaluations term flows

### DIFF
--- a/base/src/commonMain/kotlin/com/gdavidpb/tuindice/base/ui/view/WheelPicker.kt
+++ b/base/src/commonMain/kotlin/com/gdavidpb/tuindice/base/ui/view/WheelPicker.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import com.gdavidpb.tuindice.base.ui.BaseUiTags
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
@@ -42,17 +43,34 @@ fun WheelPicker(
 ) {
 	val coroutineScope = rememberCoroutineScope()
 	val currentOnItemPicked by rememberUpdatedState(onItemPicked)
+	val currentItemValidator by rememberUpdatedState(itemValidator)
 	val currentIndex = remember { mutableIntStateOf(state.firstVisibleItemIndex) }
 
 	val itemHalfHeight = with(LocalDensity.current) { itemHeight.toPx() / 2 }
 
 	LaunchedEffect(state.isScrollInProgress) {
 		if (!state.isScrollInProgress && state.firstVisibleItemScrollOffset != 0) {
-			if (state.firstVisibleItemScrollOffset < itemHalfHeight)
-				state.animateScrollToItem(state.firstVisibleItemIndex)
-			else
-				state.animateScrollToItem(state.firstVisibleItemIndex + 1)
+			state.animateScrollToItem(
+				state.targetFirstVisibleItemIndex(itemHalfHeight)
+			)
 		}
+	}
+
+	LaunchedEffect(state, additionalItemCount, itemHalfHeight) {
+		snapshotFlow {
+			state.pickedItemIndex(
+				additionalItemCount = additionalItemCount,
+				itemHalfHeight = itemHalfHeight
+			)
+		}
+			.drop(1)
+			.distinctUntilChanged()
+			.collect { index ->
+				if (currentItemValidator(index)) {
+					currentIndex.intValue = index - additionalItemCount
+					currentOnItemPicked(index)
+				}
+			}
 	}
 
 	LaunchedEffect(state) {
@@ -62,11 +80,7 @@ fun WheelPicker(
 			.collect {
 				val index = state.firstVisibleItemIndex + additionalItemCount
 
-				if (itemValidator(index)) {
-					currentIndex.intValue = state.firstVisibleItemIndex
-
-					currentOnItemPicked(index)
-				} else {
+				if (!currentItemValidator(index)) {
 					state.animateScrollToItem(currentIndex.intValue)
 				}
 			}
@@ -105,3 +119,17 @@ fun WheelPicker(
 }
 
 private const val WheelPickerItemContentType = "wheel_picker_item"
+
+private fun LazyListState.targetFirstVisibleItemIndex(itemHalfHeight: Float): Int {
+	return if (firstVisibleItemScrollOffset < itemHalfHeight)
+		firstVisibleItemIndex
+	else
+		firstVisibleItemIndex + 1
+}
+
+private fun LazyListState.pickedItemIndex(
+	additionalItemCount: Int,
+	itemHalfHeight: Float
+): Int {
+	return targetFirstVisibleItemIndex(itemHalfHeight) + additionalItemCount
+}

--- a/e2e/maestro/flows/record/record-synthetic-term-lifecycle.yaml
+++ b/e2e/maestro/flows/record/record-synthetic-term-lifecycle.yaml
@@ -44,9 +44,34 @@ appId: com.gdavidpb.tuindice.debug
     commands:
       - setClipboard: "ec"
       - pasteText
-- hideKeyboard
+- tapOn:
+    id: record_create_synthetic_term_search_clear_button
 - assertVisible:
     id: record_create_synthetic_term_search_field
+- tapOn:
+    id: record_create_synthetic_term_search_field
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - inputText: "ec"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - setClipboard: "ec"
+      - pasteText
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          point: "87%,89%"
 - scrollUntilVisible:
     element:
       id: record_create_synthetic_term_subject_EC5201_add_button
@@ -58,10 +83,55 @@ appId: com.gdavidpb.tuindice.debug
     visible:
       id: record_create_synthetic_term_subject_EC5201_remove_button
     timeout: 10000
+- scrollUntilVisible:
+    element:
+      id: record_create_synthetic_term_subject_EC5333_add_button
+    direction: DOWN
+    timeout: 20000
 - tapOn:
-    id: record_create_synthetic_term_search_clear_button
-- assertVisible:
-    id: record_create_synthetic_term_search_field
+    id: record_create_synthetic_term_subject_EC5333_add_button
+- extendedWaitUntil:
+    visible:
+      id: record_create_synthetic_term_subject_EC5333_remove_button
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      id: record_create_synthetic_term_search_field
+    direction: UP
+    timeout: 20000
+- retry:
+    maxRetries: 3
+    commands:
+      - tapOn:
+          id: record_create_synthetic_term_search_field
+      - eraseText: 20
+      - runFlow:
+          when:
+            platform: Android
+          commands:
+            - inputText: "ma"
+      - runFlow:
+          when:
+            platform: iOS
+          commands:
+            - setClipboard: "ma"
+            - pasteText
+      - runFlow:
+          when:
+            platform: Android
+          commands:
+            - hideKeyboard
+      - runFlow:
+          when:
+            platform: iOS
+          commands:
+            - tapOn:
+                point: "87%,89%"
+      - scrollUntilVisible:
+          element:
+            id: record_create_synthetic_term_subject_MA1112_add_button
+          direction: DOWN
+          timeout: 20000
 - assertVisible:
     id: record_create_synthetic_term_submit_button
     enabled: true
@@ -71,11 +141,13 @@ appId: com.gdavidpb.tuindice.debug
     visible:
       id: record_content_container
     timeout: 30000
-- tapOn:
-    id: record_term_chip_2026-SEP_DEC
 - extendedWaitUntil:
     visible:
       id: record_attempt_item_2026-SEP_DEC-EC5201-1
+    timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: record_attempt_item_2026-SEP_DEC-EC5333-2
     timeout: 15000
 - tapOn:
     id: record_edit_synthetic_term_button
@@ -85,62 +157,79 @@ appId: com.gdavidpb.tuindice.debug
     timeout: 10000
 - assertVisible:
     id: record_create_synthetic_term_subject_EC5201_remove_button
+- assertVisible:
+    id: record_create_synthetic_term_subject_EC5333_remove_button
+- tapOn:
+    id: record_create_synthetic_term_search_tab
+- runFlow:
+    when:
+      visible: "Try out your stylus"
+    commands:
+      - tapOn: "Cancel"
 - runFlow:
     when:
       platform: Android
     commands:
-      - tapOn:
-          id: record_create_synthetic_term_search_tab
-      - runFlow:
-          when:
-            visible: "Try out your stylus"
-          commands:
-            - tapOn: "Cancel"
-      - extendedWaitUntil:
-          visible:
-            id: record_create_synthetic_term_search_field
-          timeout: 10000
-      - tapOn:
-          id: record_create_synthetic_term_search_field
-      - inputText: "ec"
       - hideKeyboard
-      - assertVisible:
-          id: record_create_synthetic_term_search_field
-      - scrollUntilVisible:
-          element:
-            id: record_create_synthetic_term_subject_EC5333_add_button
-          direction: DOWN
-          timeout: 20000
-      - tapOn:
-          id: record_create_synthetic_term_subject_EC5333_add_button
-      - extendedWaitUntil:
-          visible:
-            id: record_create_synthetic_term_subject_EC5333_remove_button
-          timeout: 10000
-      - tapOn:
-          id: record_create_synthetic_term_submit_button
-      - extendedWaitUntil:
-          visible:
-            id: record_content_container
-          timeout: 30000
-      - extendedWaitUntil:
-          visible:
-            id: record_attempt_item_2026-SEP_DEC-EC5333-2
-          timeout: 15000
-- runFlow:
-    when:
-      platform: iOS
+- scrollUntilVisible:
+    element:
+      id: record_create_synthetic_term_search_field
+    direction: DOWN
+    visibilityPercentage: 50
+    timeout: 10000
+- retry:
+    maxRetries: 3
     commands:
       - tapOn:
-          id: record_create_synthetic_term_submit_button
+          id: record_create_synthetic_term_search_field
+      - eraseText: 20
+      - runFlow:
+          when:
+            platform: Android
+          commands:
+            - inputText: "ma"
+      - runFlow:
+          when:
+            platform: iOS
+          commands:
+            - setClipboard: "ma"
+            - pasteText
+      - runFlow:
+          when:
+            platform: Android
+          commands:
+            - hideKeyboard
+      - runFlow:
+          when:
+            platform: iOS
+          commands:
+            - tapOn:
+                point: "87%,89%"
       - extendedWaitUntil:
           visible:
-            id: record_content_container
-          timeout: 30000
-      - extendedWaitUntil:
-          visible:
-            id: record_attempt_item_2026-SEP_DEC-EC5201-1
-          timeout: 15000
+            id: record_create_synthetic_term_search_results_title
+          timeout: 20000
+- scrollUntilVisible:
+    element:
+      id: record_create_synthetic_term_subject_MA1121_add_button
+    direction: DOWN
+    timeout: 20000
+- tapOn:
+    id: record_create_synthetic_term_subject_MA1121_add_button
+- extendedWaitUntil:
+    visible:
+      id: record_create_synthetic_term_subject_MA1121_remove_button
+    timeout: 10000
+- tapOn:
+    id: record_create_synthetic_term_submit_button
+- extendedWaitUntil:
+    visible:
+      id: record_content_container
+    timeout: 30000
+- extendedWaitUntil:
+    visible:
+      id: record_attempt_item_2026-SEP_DEC-MA1121-3
+    timeout: 15000
 - tapOn:
     id: record_term_chip_2026-SEP_DEC
 - extendedWaitUntil:

--- a/e2e/maestro/flows/record/record-synthetic-term-search-empty.yaml
+++ b/e2e/maestro/flows/record/record-synthetic-term-search-empty.yaml
@@ -39,7 +39,17 @@ appId: com.gdavidpb.tuindice.debug
     commands:
       - setClipboard: "zz"
       - pasteText
-- hideKeyboard
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          point: "87%,89%"
 - assertVisible:
     id: record_create_synthetic_term_search_field
 - extendedWaitUntil:

--- a/e2e/maestro/flows/record/record-synthetic-term-search-states.yaml
+++ b/e2e/maestro/flows/record/record-synthetic-term-search-states.yaml
@@ -53,8 +53,19 @@ appId: com.gdavidpb.tuindice.debug
           when:
             platform: iOS
           commands:
-            - inputText: "prioridad"
-      - hideKeyboard
+            - setClipboard: "prioridad"
+            - pasteText
+      - runFlow:
+          when:
+            platform: Android
+          commands:
+            - hideKeyboard
+      - runFlow:
+          when:
+            platform: iOS
+          commands:
+            - tapOn:
+                point: "87%,89%"
       - extendedWaitUntil:
           visible:
             id: record_create_synthetic_term_search_result_0_subject_EP1308
@@ -155,8 +166,19 @@ appId: com.gdavidpb.tuindice.debug
           when:
             platform: iOS
           commands:
-            - inputText: "ma"
-      - hideKeyboard
+            - setClipboard: "ma"
+            - pasteText
+      - runFlow:
+          when:
+            platform: Android
+          commands:
+            - hideKeyboard
+      - runFlow:
+          when:
+            platform: iOS
+          commands:
+            - tapOn:
+                point: "87%,89%"
       - extendedWaitUntil:
           visible:
             id: record_create_synthetic_term_search_result_0_subject_MA1112
@@ -191,8 +213,19 @@ appId: com.gdavidpb.tuindice.debug
           when:
             platform: iOS
           commands:
-            - inputText: "ma1111"
-      - hideKeyboard
+            - setClipboard: "ma1111"
+            - pasteText
+      - runFlow:
+          when:
+            platform: Android
+          commands:
+            - hideKeyboard
+      - runFlow:
+          when:
+            platform: iOS
+          commands:
+            - tapOn:
+                point: "87%,89%"
       - extendedWaitUntil:
           visible:
             id: record_create_synthetic_term_taken_subjects_toggle

--- a/evaluations/src/commonMain/composeResources/values/strings.xml
+++ b/evaluations/src/commonMain/composeResources/values/strings.xml
@@ -6,8 +6,8 @@
 	<string name="top_bar_edit_evaluation">Modificar evaluación</string>
 	<string name="state_message_loading">Cargando...</string>
 
-	<string name="title_empty_evaluations">Organizando evaluaciones</string>
-	<string name="message_empty_evaluations">Agrega tu primera evaluación para ordenar pendientes, fechas y notas.</string>
+	<string name="title_empty_evaluations">Empieza con una evaluación</string>
+	<string name="message_empty_evaluations">Registra el primer parcial, quiz o entrega de este trimestre.</string>
 	<string name="title_no_subjects_evaluations">Sin trimestre en curso</string>
 	<string name="message_no_subjects_evaluations">Cuando tengas un trimestre activo, podrás agregar evaluaciones desde aquí.</string>
 	<string name="title_empty_match_evaluations">Sin resultados</string>

--- a/evaluations/src/commonMain/kotlin/com/gdavidpb/tuindice/evaluations/data/source/RoomDatabaseDataSource.kt
+++ b/evaluations/src/commonMain/kotlin/com/gdavidpb/tuindice/evaluations/data/source/RoomDatabaseDataSource.kt
@@ -1,7 +1,6 @@
 package com.gdavidpb.tuindice.evaluations.data.source
 
 import com.gdavidpb.tuindice.academiccore.domain.model.TermKind
-import com.gdavidpb.tuindice.academiccore.domain.model.isEditable
 import com.gdavidpb.tuindice.base.utils.currentTimeMillis
 import com.gdavidpb.tuindice.base.domain.model.GradingMode
 import com.gdavidpb.tuindice.evaluations.data.mapper.toEvaluationEntity
@@ -90,7 +89,7 @@ class RoomDatabaseDataSource(
 	}
 
 	override suspend fun getAvailableAttempts(): List<LocalEditableAttemptDescriptor> {
-		val currentEditableTermId = selectCurrentEditableTermId(
+		val currentTermId = selectOfficialCurrentTermId(
 			terms = academicTermDao.getTerms(),
 			nowMillis = currentTimeMillis()
 		) ?: return emptyList()
@@ -98,7 +97,7 @@ class RoomDatabaseDataSource(
 		return academicAttemptDao
 			.getAttempts()
 			.asSequence()
-			.filter { attempt -> attempt.termId == currentEditableTermId }
+			.filter { attempt -> attempt.termId == currentTermId }
 			.filter { attempt -> attempt.gradingMode == "NUMERIC" }
 			.map { attempt -> attempt.toLocalEditableAttemptDescriptor() }
 			.filter { attempt -> attempt.gradingMode == GradingMode.NUMERIC }
@@ -230,30 +229,20 @@ class RoomDatabaseDataSource(
 	}
 
 	internal companion object {
-		fun isEditableTermKind(kind: String): Boolean {
-			return TermKind.valueOf(kind).isEditable
-		}
-
-		fun selectCurrentEditableTermId(
+		fun selectOfficialCurrentTermId(
 			terms: List<AcademicTermEntity>,
 			@Suppress("UNUSED_PARAMETER")
 			nowMillis: Long
 		): String? {
-			val editableTerms = terms.filter { term -> isEditableTermKind(term.kind) }
-			if (editableTerms.isEmpty()) return null
-
 			val termComparator = compareBy(
 				AcademicTermEntity::termOrder,
 				AcademicTermEntity::id
 			)
 
-			return editableTerms
+			return terms
 				.filter { term -> TermKind.valueOf(term.kind) == TermKind.CURRENT }
 				.maxWithOrNull(termComparator)
 				?.id
-				?: editableTerms
-					.minWithOrNull(termComparator)
-					?.id
 		}
 	}
 }

--- a/evaluations/src/commonTest/kotlin/com/gdavidpb/tuindice/evaluations/data/source/RoomDatabaseDataSourceTermKindTest.kt
+++ b/evaluations/src/commonTest/kotlin/com/gdavidpb/tuindice/evaluations/data/source/RoomDatabaseDataSourceTermKindTest.kt
@@ -4,23 +4,11 @@ import com.gdavidpb.tuindice.academiccore.domain.model.TermKind
 import com.gdavidpb.tuindice.persistence.data.room.entity.AcademicTermEntity
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.test.assertNull
 
 class RoomDatabaseDataSourceTermKindTest {
 	@Test
-	fun isEditableTermKind_returnsTrue_forCurrentAndSyntheticTerms() {
-		assertTrue(RoomDatabaseDataSource.isEditableTermKind(TermKind.CURRENT.name))
-		assertTrue(RoomDatabaseDataSource.isEditableTermKind(TermKind.SYNTHETIC.name))
-	}
-
-	@Test
-	fun isEditableTermKind_returnsFalse_forHistoricalHistoricalTerms() {
-		assertFalse(RoomDatabaseDataSource.isEditableTermKind(TermKind.HISTORICAL.name))
-	}
-
-	@Test
-	fun selectCurrentEditableTermId_prefersCurrentTerm() {
+	fun selectOfficialCurrentTermId_prefersCurrentTerm() {
 		val terms = listOf(
 			academicTerm(
 				id = "11111111111111111111111111111111",
@@ -41,7 +29,7 @@ class RoomDatabaseDataSourceTermKindTest {
 
 		assertEquals(
 			"11111111111111111111111111111111",
-			RoomDatabaseDataSource.selectCurrentEditableTermId(
+			RoomDatabaseDataSource.selectOfficialCurrentTermId(
 				terms = terms,
 				nowMillis = 1_776_124_800_000L
 			)
@@ -49,7 +37,7 @@ class RoomDatabaseDataSourceTermKindTest {
 	}
 
 	@Test
-	fun selectCurrentEditableTermId_fallsBackToEarliestEditableTerm_whenNoCurrentExists() {
+	fun selectOfficialCurrentTermId_returnsNull_whenNoCurrentExists() {
 		val terms = listOf(
 			academicTerm(
 				id = "11111111111111111111111111111111",
@@ -68,9 +56,8 @@ class RoomDatabaseDataSourceTermKindTest {
 			)
 		)
 
-		assertEquals(
-			"22222222222222222222222222222222",
-			RoomDatabaseDataSource.selectCurrentEditableTermId(
+		assertNull(
+			RoomDatabaseDataSource.selectOfficialCurrentTermId(
 				terms = terms,
 				nowMillis = 1_787_000_000_000L
 			)
@@ -78,7 +65,7 @@ class RoomDatabaseDataSourceTermKindTest {
 	}
 
 	@Test
-	fun selectCurrentEditableTermId_ignoresHistoricalTerms_whenChoosingFallback() {
+	fun selectOfficialCurrentTermId_ignoresHistoricalAndSyntheticTerms() {
 		val terms = listOf(
 			academicTerm(
 				id = "44444444444444444444444444444444",
@@ -92,11 +79,34 @@ class RoomDatabaseDataSourceTermKindTest {
 			)
 		)
 
-		assertEquals(
-			"22222222222222222222222222222222",
-			RoomDatabaseDataSource.selectCurrentEditableTermId(
+		assertNull(
+			RoomDatabaseDataSource.selectOfficialCurrentTermId(
 				terms = terms,
 				nowMillis = 1_774_000_000_000L
+			)
+		)
+	}
+
+	@Test
+	fun selectOfficialCurrentTermId_returnsLatestCurrentTerm_whenMultipleCurrentTermsExist() {
+		val terms = listOf(
+			academicTerm(
+				id = "11111111111111111111111111111111",
+				termOrder = 20261,
+				kind = TermKind.CURRENT.name
+			),
+			academicTerm(
+				id = "22222222222222222222222222222222",
+				termOrder = 20262,
+				kind = TermKind.CURRENT.name
+			)
+		)
+
+		assertEquals(
+			"22222222222222222222222222222222",
+			RoomDatabaseDataSource.selectOfficialCurrentTermId(
+				terms = terms,
+				nowMillis = 1_787_000_000_000L
 			)
 		)
 	}

--- a/evaluations/src/commonTest/kotlin/com/gdavidpb/tuindice/evaluations/ui/dialog/GradePickerDialogUiTest.kt
+++ b/evaluations/src/commonTest/kotlin/com/gdavidpb/tuindice/evaluations/ui/dialog/GradePickerDialogUiTest.kt
@@ -2,9 +2,13 @@ package com.gdavidpb.tuindice.evaluations.ui.dialog
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
+import com.gdavidpb.tuindice.base.ui.BaseUiTags
 import com.gdavidpb.tuindice.evaluations.ui.EvaluationsUiTags
 import com.gdavidpb.tuindice.evaluations.ui.model.MIN_EVALUATION_GRADE
 import com.gdavidpb.tuindice.testkit.ui.assertNodeVisible
@@ -12,6 +16,8 @@ import com.gdavidpb.tuindice.testkit.ui.runTuIndiceUiTest
 import com.gdavidpb.tuindice.testkit.ui.setTuIndiceTestContent
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotEquals
 
 @OptIn(ExperimentalTestApi::class)
 class GradePickerDialogUiTest {
@@ -156,6 +162,34 @@ class GradePickerDialogUiTest {
 		onNodeWithTag(EvaluationsUiTags.EvaluationDialogConfirmButton).performClick()
 
 		assertEquals(17.25, changedGrade)
+	}
+
+	@Test
+	fun when_wheelScrolledAndConfirmTappedImmediately_then_emitsScrolledGrade() = runTuIndiceUiTest {
+		var changedGrade: Double? = null
+
+		setTuIndiceTestContent {
+			GradePickerDialog(
+				title = "Nota maxima",
+				evaluationName = "Parcial 1",
+				subjectCode = "MA1111",
+				acceptText = "Aceptar",
+				cancelText = "Cancelar",
+				selectedGrade = 10.0,
+				gradeRange = 0.0..20.0,
+				onGradeChange = { grade ->
+					changedGrade = grade
+				},
+				onDismissRequest = {}
+			)
+		}
+
+		onAllNodesWithTag(BaseUiTags.WheelPickerList)[0]
+			.performTouchInput { swipeUp() }
+		onNodeWithTag(EvaluationsUiTags.EvaluationDialogConfirmButton).performClick()
+
+		assertNotNull(changedGrade)
+		assertNotEquals(10.0, changedGrade)
 	}
 
 	@Test

--- a/gradle/app-version.properties
+++ b/gradle/app-version.properties
@@ -1,3 +1,3 @@
-versionName=6.1.3
-androidVersionCode=43
-iosBuildNumber=31
+versionName=6.1.4
+androidVersionCode=44
+iosBuildNumber=32

--- a/iosApp/Config/Version.xcconfig
+++ b/iosApp/Config/Version.xcconfig
@@ -1,3 +1,3 @@
 // Generated from gradle/app-version.properties. Do not edit directly.
-MARKETING_VERSION = 6.1.3
-CURRENT_PROJECT_VERSION = 31
+MARKETING_VERSION = 6.1.4
+CURRENT_PROJECT_VERSION = 32

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/CreateSyntheticTermUseCase.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/CreateSyntheticTermUseCase.kt
@@ -18,10 +18,10 @@ class CreateSyntheticTermUseCase(
 	private val repository: AcademicRecordRepository,
 	override val reportingRepository: ReportingRepository,
 	override val exceptionHandler: RecordExceptionHandler
-) : FlowUseCase<CreateSyntheticTermParams, Unit, RecordUseCaseError>(
+) : FlowUseCase<CreateSyntheticTermParams, String, RecordUseCaseError>(
 	reportingRepository = reportingRepository
 ) {
-	override suspend fun executeOnBackground(params: CreateSyntheticTermParams): Flow<Unit> {
+	override suspend fun executeOnBackground(params: CreateSyntheticTermParams): Flow<String> {
 		val record = repository.getAcademicRecord()
 			?: throw SyntheticTermValidationException(SyntheticTermValidationError.RECORD_UNAVAILABLE)
 		SyntheticTermCommandValidator.validate(
@@ -46,8 +46,8 @@ class CreateSyntheticTermUseCase(
 						outcome = AttemptOutcome.PENDING
 					)
 				}
+				)
 			)
-		)
-		return flowOf(Unit)
+			return flowOf(termId)
 	}
 }

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/UpdateSyntheticTermUseCase.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/domain/usecase/UpdateSyntheticTermUseCase.kt
@@ -18,10 +18,10 @@ class UpdateSyntheticTermUseCase(
 	private val repository: AcademicRecordRepository,
 	override val reportingRepository: ReportingRepository,
 	override val exceptionHandler: RecordExceptionHandler
-) : FlowUseCase<CreateSyntheticTermParams, Unit, RecordUseCaseError>(
+) : FlowUseCase<CreateSyntheticTermParams, String, RecordUseCaseError>(
 	reportingRepository = reportingRepository
 ) {
-	override suspend fun executeOnBackground(params: CreateSyntheticTermParams): Flow<Unit> {
+	override suspend fun executeOnBackground(params: CreateSyntheticTermParams): Flow<String> {
 		val targetTermId = requireNotNull(params.editingTermId)
 		val targetTermKey = requireNotNull(params.editingTermKey)
 		val record = repository.getAcademicRecord()
@@ -56,8 +56,8 @@ class UpdateSyntheticTermUseCase(
 						outcome = AttemptOutcome.PENDING
 					)
 				}
+				)
 			)
-		)
-		return flowOf(Unit)
+			return flowOf(termId)
 	}
 }

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/presentation/action/CreateSyntheticTermActionProcessor.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/presentation/action/CreateSyntheticTermActionProcessor.kt
@@ -4,13 +4,17 @@ import com.gdavidpb.tuindice.base.domain.usecase.base.UseCaseState
 import com.gdavidpb.tuindice.base.presentation.Mutation
 import com.gdavidpb.tuindice.base.presentation.action.ActionProcessor
 import com.gdavidpb.tuindice.base.presentation.model.UiText
+import com.gdavidpb.tuindice.record.domain.model.RecordViewMode
 import com.gdavidpb.tuindice.record.domain.model.SyntheticTermValidationError
 import com.gdavidpb.tuindice.record.domain.usecase.CreateSyntheticTermUseCase
+import com.gdavidpb.tuindice.record.domain.usecase.SetSelectedTermUseCase
 import com.gdavidpb.tuindice.record.domain.usecase.UpdateSyntheticTermUseCase
 import com.gdavidpb.tuindice.record.domain.usecase.error.RecordUseCaseError
 import com.gdavidpb.tuindice.record.domain.usecase.param.CreateSyntheticTermParams
+import com.gdavidpb.tuindice.record.domain.usecase.param.SetSelectedTermParams
 import com.gdavidpb.tuindice.record.presentation.contract.CreateSyntheticTerm
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import tuindice.record.generated.resources.Res
 import tuindice.record.generated.resources.create_term_error_duplicate_subject
@@ -24,7 +28,8 @@ import tuindice.record.generated.resources.create_term_error_term_must_be_after_
 
 class CreateSyntheticTermActionProcessor(
 	private val createSyntheticTermUseCase: CreateSyntheticTermUseCase,
-	private val updateSyntheticTermUseCase: UpdateSyntheticTermUseCase
+	private val updateSyntheticTermUseCase: UpdateSyntheticTermUseCase,
+	private val setSelectedTermUseCase: SetSelectedTermUseCase
 ) : ActionProcessor<
 	CreateSyntheticTerm.State,
 	CreateSyntheticTerm.Action.CreateTerm,
@@ -60,6 +65,12 @@ class CreateSyntheticTermActionProcessor(
 						)
 
 					is UseCaseState.Data -> {
+						setSelectedTermUseCase.execute(
+							SetSelectedTermParams(
+								viewMode = RecordViewMode.Projection,
+								termId = useCaseState.value
+							)
+						).collect()
 						emit(
 							suspend { state: CreateSyntheticTerm.State ->
 								state.copy(

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/presentation/mapper/AttemptItem.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/presentation/mapper/AttemptItem.kt
@@ -31,7 +31,7 @@ fun AttemptProjection.toAttemptItem(
 		outcome = resolvedOutcome,
 		badge = badge,
 		codeText = subjectCode,
-		nameText = subjectName,
+		nameText = subjectName.uppercase(),
 		gradeText = if (
 			(this.gradingMode == AttemptGradingMode.NUMERIC) &&
 			(

--- a/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/ui/screen/CreateSyntheticTermScreen.kt
+++ b/record/src/commonMain/kotlin/com/gdavidpb/tuindice/record/ui/screen/CreateSyntheticTermScreen.kt
@@ -1,6 +1,9 @@
 package com.gdavidpb.tuindice.record.ui.screen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitTouchSlopOrCancellation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -19,10 +22,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextRange
@@ -43,7 +46,6 @@ import com.gdavidpb.tuindice.record.ui.view.CreateTermSectionTitle
 import com.gdavidpb.tuindice.record.ui.view.CreateTermSelectedSubjectCard
 import com.gdavidpb.tuindice.record.ui.view.CreateTermSubmitBar
 import com.gdavidpb.tuindice.record.ui.view.CreateTermSuggestedSubjectCard
-import kotlinx.coroutines.flow.distinctUntilChanged
 import org.jetbrains.compose.resources.stringResource
 import tuindice.record.generated.resources.Res
 import tuindice.record.generated.resources.create_term_add_subjects_title
@@ -102,16 +104,6 @@ fun CreateSyntheticTermScreen(
 		focusManager.clearFocus()
 	}
 
-	LaunchedEffect(lazyListState) {
-		snapshotFlow { lazyListState.isScrollInProgress }
-			.distinctUntilChanged()
-			.collect { isScrollInProgress ->
-				if (isScrollInProgress) {
-					dismissKeyboard()
-				}
-			}
-	}
-
 	val takenSearchResultsCount = searchResultsWithoutSelectedSubjects.count { subject ->
 		subject.availability == SyntheticTermSubjectAvailability.ALREADY_TAKEN
 	}
@@ -134,6 +126,14 @@ fun CreateSyntheticTermScreen(
 				.fillMaxSize()
 				.padding(horizontal = 20.dp)
 				.imePadding()
+				.pointerInput(Unit) {
+					awaitEachGesture {
+						val down = awaitFirstDown(requireUnconsumed = false)
+						awaitTouchSlopOrCancellation(down.id) { _, _ ->
+							dismissKeyboard()
+						}
+					}
+				}
 				.testTag(RecordUiTags.CreateSyntheticTermContentList),
 			state = lazyListState,
 			contentPadding = PaddingValues(

--- a/record/src/commonTest/kotlin/com/gdavidpb/tuindice/record/domain/usecase/CreateSyntheticTermUseCaseTest.kt
+++ b/record/src/commonTest/kotlin/com/gdavidpb/tuindice/record/domain/usecase/CreateSyntheticTermUseCaseTest.kt
@@ -83,7 +83,7 @@ class CreateSyntheticTermUseCaseTest {
 			.execute(createParams(subjects = listOf(syntheticSubject("MA1112"))))
 			.toList()
 
-		val errorState = assertIs<UseCaseState.Error<Unit, RecordUseCaseError>>(states.last())
+		val errorState = assertIs<UseCaseState.Error<String, RecordUseCaseError>>(states.last())
 		val error = assertIs<RecordUseCaseError.SyntheticTermValidation>(errorState.error)
 		assertEquals(SyntheticTermValidationError.SUBJECT_ALREADY_TAKEN, error.reason)
 		assertEquals(emptyList(), repository.addedTerms)
@@ -108,7 +108,7 @@ class CreateSyntheticTermUseCaseTest {
 			.execute(createParams(subjects = listOf(syntheticSubject("MA1112"))))
 			.toList()
 
-		val errorState = assertIs<UseCaseState.Error<Unit, RecordUseCaseError>>(states.last())
+		val errorState = assertIs<UseCaseState.Error<String, RecordUseCaseError>>(states.last())
 		val error = assertIs<RecordUseCaseError.SyntheticTermValidation>(errorState.error)
 		assertEquals(SyntheticTermValidationError.TERM_ALREADY_EXISTS, error.reason)
 		assertEquals(emptyList(), repository.addedTerms)

--- a/record/src/commonTest/kotlin/com/gdavidpb/tuindice/record/presentation/action/CreateSyntheticTermActionProcessorTest.kt
+++ b/record/src/commonTest/kotlin/com/gdavidpb/tuindice/record/presentation/action/CreateSyntheticTermActionProcessorTest.kt
@@ -8,18 +8,22 @@ import com.gdavidpb.tuindice.academiccore.domain.model.AttemptOutcome
 import com.gdavidpb.tuindice.academiccore.domain.model.AttemptScore
 import com.gdavidpb.tuindice.academiccore.domain.model.TermKind
 import com.gdavidpb.tuindice.base.presentation.model.UiText
+import com.gdavidpb.tuindice.record.domain.model.RecordViewMode
 import com.gdavidpb.tuindice.record.domain.model.SyntheticTermCreationCommand
 import com.gdavidpb.tuindice.record.domain.model.SyntheticTermPeriodOption
 import com.gdavidpb.tuindice.record.domain.model.SyntheticTermSubject
 import com.gdavidpb.tuindice.record.domain.model.SyntheticTermUpdateCommand
 import com.gdavidpb.tuindice.record.domain.repository.AcademicRecordRepository
+import com.gdavidpb.tuindice.record.domain.repository.RecordSelectionRepository
 import com.gdavidpb.tuindice.record.domain.usecase.CreateSyntheticTermUseCase
+import com.gdavidpb.tuindice.record.domain.usecase.SetSelectedTermUseCase
 import com.gdavidpb.tuindice.record.domain.usecase.UpdateSyntheticTermUseCase
 import com.gdavidpb.tuindice.record.domain.usecase.exceptionhandler.RecordExceptionHandler
 import com.gdavidpb.tuindice.record.presentation.contract.CreateSyntheticTerm
 import com.gdavidpb.tuindice.testkit.base.repository.RecordingReportingRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -29,6 +33,53 @@ import tuindice.record.generated.resources.Res
 import tuindice.record.generated.resources.create_term_error_subject_already_taken
 
 class CreateSyntheticTermActionProcessorTest {
+	@Test
+	fun process_whenCreateSucceeds_selectsCreatedProjectionTermAndNavigatesBack() = runTest {
+		val repository = RecordingAcademicRecordRepository(
+			record = AcademicRecord(
+				id = "record",
+				terms = emptyList()
+			)
+		)
+		val selectionRepository = RecordingCreateTermSelectionRepository()
+		val effects = mutableListOf<CreateSyntheticTerm.Effect>()
+		val mutations = processor(
+			repository = repository,
+			selectionRepository = selectionRepository
+		).process(
+			action = CreateSyntheticTerm.Action.CreateTerm(
+				editingTermId = null,
+				editingTermKey = null,
+				period = SyntheticTermPeriodOption(
+					periodYear = 9999,
+					periodCode = AcademicTermPeriod.JAN_MAR
+				),
+				subjects = listOf(
+					SyntheticTermSubject(
+						subjectCode = "MA1112",
+						name = "Matemáticas II",
+						credits = 4
+					)
+				)
+			),
+			sideEffect = { effect -> effects += effect }
+		).toList()
+
+		var state = CreateSyntheticTerm.State(isSubmitting = true)
+		for (mutation in mutations) {
+			state = mutation(state)
+		}
+
+		assertEquals(false, state.isSubmitting)
+		assertEquals("9999-JAN_MAR", repository.addedTerms.single().termId)
+		assertEquals(
+			"9999-JAN_MAR",
+			selectionRepository.selectedTermIds.getValue(RecordViewMode.Projection)
+		)
+		assertEquals(1, effects.size)
+		assertEquals(CreateSyntheticTerm.Effect.NavigateBack, effects.single())
+	}
+
 	@Test
 	fun process_whenLocalValidationFails_keepsUserInCreateFlowAndShowsSubmitError() = runTest {
 		val repository = RecordingAcademicRecordRepository(
@@ -86,7 +137,10 @@ class CreateSyntheticTermActionProcessorTest {
 		assertTrue(effects.isEmpty())
 	}
 
-	private fun processor(repository: AcademicRecordRepository): CreateSyntheticTermActionProcessor {
+	private fun processor(
+		repository: AcademicRecordRepository,
+		selectionRepository: RecordSelectionRepository = RecordingCreateTermSelectionRepository()
+	): CreateSyntheticTermActionProcessor {
 		val reportingRepository = RecordingReportingRepository()
 		val exceptionHandler = RecordExceptionHandler()
 		return CreateSyntheticTermActionProcessor(
@@ -99,6 +153,10 @@ class CreateSyntheticTermActionProcessorTest {
 				repository = repository,
 				reportingRepository = reportingRepository,
 				exceptionHandler = exceptionHandler
+			),
+			setSelectedTermUseCase = SetSelectedTermUseCase(
+				recordSelectionRepository = selectionRepository,
+				reportingRepository = reportingRepository
 			)
 		)
 	}
@@ -135,4 +193,26 @@ private class RecordingAcademicRecordRepository(
 	override suspend fun updateSyntheticTerm(command: SyntheticTermUpdateCommand) = Unit
 
 	override suspend fun deleteSyntheticTerm(termId: String) = Unit
+}
+
+private class RecordingCreateTermSelectionRepository : RecordSelectionRepository {
+	val selectedTermIds = mutableMapOf<RecordViewMode, String>()
+
+	override fun observeSelectedTermId(viewMode: RecordViewMode): Flow<String?> {
+		return flowOf(selectedTermIds[viewMode])
+	}
+
+	override fun observeRecordViewMode(): Flow<RecordViewMode> = flowOf(RecordViewMode.Projection)
+
+	override suspend fun getSelectedTermId(viewMode: RecordViewMode): String? {
+		return selectedTermIds[viewMode]
+	}
+
+	override suspend fun setSelectedTermId(viewMode: RecordViewMode, termId: String) {
+		selectedTermIds[viewMode] = termId
+	}
+
+	override suspend fun getRecordViewMode(): RecordViewMode = RecordViewMode.Projection
+
+	override suspend fun setRecordViewMode(viewMode: RecordViewMode) = Unit
 }

--- a/record/src/commonTest/kotlin/com/gdavidpb/tuindice/record/ui/screen/RecordScreenUiTest.kt
+++ b/record/src/commonTest/kotlin/com/gdavidpb/tuindice/record/ui/screen/RecordScreenUiTest.kt
@@ -1,8 +1,13 @@
 package com.gdavidpb.tuindice.record.ui.screen
 
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.gdavidpb.tuindice.academiccore.domain.model.AcademicAttempt
 import com.gdavidpb.tuindice.academiccore.domain.model.AcademicRecord
 import com.gdavidpb.tuindice.academiccore.domain.model.AcademicTerm
 import com.gdavidpb.tuindice.academiccore.domain.model.AcademicTermPeriod
@@ -19,6 +24,35 @@ import kotlin.test.assertEquals
 
 @OptIn(ExperimentalTestApi::class)
 class RecordScreenUiTest {
+	@Test
+	fun when_attemptNameUsesMixedCase_then_recordDisplaysUppercaseName() = runTuIndiceUiTest {
+		setTuIndiceTestContent {
+			RecordScreen(
+				state = contentState(
+					termKind = TermKind.SYNTHETIC,
+					attempts = listOf(
+						AcademicAttempt(
+							id = "attempt-1",
+							subjectCode = "MA1112",
+							subjectName = "Matemáticas II",
+							credits = 4
+						)
+					)
+				),
+				selectedTermId = SyntheticTermId,
+				onSelectedTermChange = {},
+				onRetryClick = {},
+				onAttemptSelectionChange = { _, _, _, _ -> },
+				onCreateSyntheticTermClick = {},
+				onUpdateSyntheticTermClick = {},
+				onDeleteSyntheticTermClick = {}
+			)
+		}
+
+		onNodeWithText("MATEMÁTICAS II").assertIsDisplayed()
+		onAllNodesWithText("Matemáticas II").assertCountEquals(0)
+	}
+
 	@Test
 	fun when_selectedTermIsSynthetic_then_overlayActionsAreShownAndClickable() = runTuIndiceUiTest {
 		var editedTermId: String? = null
@@ -76,7 +110,8 @@ class RecordScreenUiTest {
 
 	private fun contentState(
 		termId: String = SyntheticTermId,
-		termKind: TermKind
+		termKind: TermKind,
+		attempts: List<AcademicAttempt> = emptyList()
 	): Record.State.Content {
 		return Record.State.Content(
 			viewMode = RecordViewMode.Projection,
@@ -87,7 +122,8 @@ class RecordScreenUiTest {
 						id = termId,
 						periodYear = 2026,
 						periodCode = AcademicTermPeriod.SEP_DEC,
-						kind = termKind
+						kind = termKind,
+						attempts = attempts
 					)
 				)
 			),


### PR DESCRIPTION
## Summary

- Restrict evaluations data to the official current term and update related presentation text.
- Fix synthetic term focus, selection, and wheel picker propagation in record flows.
- Stabilize record Maestro E2E coverage for synthetic term lifecycle and search states.
- Bump the app version to 6.1.4.

## Validation

- E2E completed on the current branch before opening this PR, per request.
- Local branch was clean and matched `origin/feat/record-evaluations-fixes` at `d214fb99c` before PR creation.
