### PR TITLE
Require platform build number bumps

### DIFF
--- a/.github/scripts/detect-changed-app.sh
+++ b/.github/scripts/detect-changed-app.sh
@@ -38,6 +38,7 @@ APP_VERSION_CHANGED=false
 APP_VERSION_NAME_CHANGED=false
 ANDROID_VERSION_CODE_CHANGED=false
 IOS_BUILD_NUMBER_CHANGED=false
+APP_RELEASE_BUILD_NUMBERS_CHANGED=false
 CI_CONFIG_TOUCHED=false
 IOS_CI_SCRIPTS_TOUCHED=false
 E2E_CONTRACT_TOUCHED=false
@@ -486,6 +487,9 @@ if [[ "$APP_VERSION_TOUCHED" == "true" ]]; then
 	if [[ "$base_ios_build" != "$head_ios_build" ]]; then
 		IOS_BUILD_NUMBER_CHANGED=true
 	fi
+	if [[ "$ANDROID_VERSION_CODE_CHANGED" == "true" && "$IOS_BUILD_NUMBER_CHANGED" == "true" ]]; then
+		APP_RELEASE_BUILD_NUMBERS_CHANGED=true
+	fi
 
 	if [[ "$APP_VERSION_NAME_CHANGED" == "true" || "$ANDROID_VERSION_CODE_CHANGED" == "true" || "$IOS_BUILD_NUMBER_CHANGED" == "true" ]]; then
 		APP_VERSION_CHANGED=true
@@ -500,8 +504,13 @@ if [[ "$APP_VERSION_NAME_CHANGED" == "true" || "$IOS_BUILD_NUMBER_CHANGED" == "t
 	append_runtime_module iosApp
 fi
 
-if [[ "$HAS_RELEASE_IMPACT" == "true" && "$APP_VERSION_CHANGED" != "true" ]]; then
-	append_unique_line "$MISSING_VERSION_BUMP_FILE" app
+if [[ "$HAS_RELEASE_IMPACT" == "true" || "$APP_VERSION_CHANGED" == "true" ]]; then
+	if [[ "$ANDROID_VERSION_CODE_CHANGED" != "true" ]]; then
+		append_unique_line "$MISSING_VERSION_BUMP_FILE" androidVersionCode
+	fi
+	if [[ "$IOS_BUILD_NUMBER_CHANGED" != "true" ]]; then
+		append_unique_line "$MISSING_VERSION_BUMP_FILE" iosBuildNumber
+	fi
 fi
 
 if [[ "$APP_VERSION_CHANGED" == "true" ]]; then
@@ -593,6 +602,7 @@ info "Impacted modules: $(file_to_csv "$IMPACTED_MODULES_FILE" || true)"
 info "Release impacted modules: $(file_to_csv "$RELEASE_IMPACTED_MODULES_FILE" || true)"
 info "App version touched: ${APP_VERSION_TOUCHED}"
 info "App version changed: ${APP_VERSION_CHANGED}"
+info "App release build numbers changed: ${APP_RELEASE_BUILD_NUMBERS_CHANGED}"
 info "Missing version bump: $(file_to_csv "$MISSING_VERSION_BUMP_FILE" || true)"
 info "CI/CD configuration touched: ${CI_CONFIG_TOUCHED}"
 info "iOS CI scripts touched: ${IOS_CI_SCRIPTS_TOUCHED}"
@@ -619,6 +629,7 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
 		printf 'ios_tasks_file=%s\n' "$IOS_TASKS_FILE"
 		printf 'app_version_touched=%s\n' "$APP_VERSION_TOUCHED"
 		printf 'app_version_changed=%s\n' "$APP_VERSION_CHANGED"
+		printf 'app_release_build_numbers_changed=%s\n' "$APP_RELEASE_BUILD_NUMBERS_CHANGED"
 		printf 'ci_config_touched=%s\n' "$CI_CONFIG_TOUCHED"
 		printf 'ios_ci_scripts_touched=%s\n' "$IOS_CI_SCRIPTS_TOUCHED"
 		printf 'e2e_contract_touched=%s\n' "$E2E_CONTRACT_TOUCHED"

--- a/.github/scripts/preflight-production.sh
+++ b/.github/scripts/preflight-production.sh
@@ -313,7 +313,7 @@ fi
 bash "${SCRIPT_DIR}/validate-app-version.sh"
 
 if file_has_entries "$MISSING_VERSION_BUMP_FILE"; then
-	die "Runtime app changes were detected, but $(app_version_file) did not change. Bump versionName/androidVersionCode/iosBuildNumber before deploying."
+	die "Runtime app changes or app version changes require both androidVersionCode and iosBuildNumber to change. Bump the missing build number(s) in $(app_version_file) before deploying."
 fi
 
 if [[ "${SKIP_E2E_STATUS_CHECK:-0}" != "1" && "$REQUIRES_E2E_CERTIFICATION" == "true" ]]; then

--- a/.github/scripts/test-appstore-connect-check.sh
+++ b/.github/scripts/test-appstore-connect-check.sh
@@ -91,7 +91,10 @@ case "$url" in
 		printf '{"data":[{"id":"app-1"}]}\n' >"$output_file"
 		;;
 	*/builds\?*)
-		if [[ "$mode" == "exists" ]]; then
+		if [[ "$mode" == "exists" || "$mode" == "exists-other-version" ]]; then
+			if [[ "$mode" == "exists-other-version" ]]; then
+				version_name="0.0.0"
+			fi
 			jq -n --arg version_name "$version_name" '{
 				data: [
 					{
@@ -149,5 +152,6 @@ SH
 
 run_appstore_check_fixture missing false ""
 run_appstore_check_fixture exists true build-1
+run_appstore_check_fixture exists-other-version true build-1
 
 printf 'App Store Connect check-only fixtures passed for %s (%s).\n' "$VERSION_NAME" "$IOS_BUILD_NUMBER"

--- a/.github/scripts/test-detect-changed-app.sh
+++ b/.github/scripts/test-detect-changed-app.sh
@@ -55,14 +55,14 @@ assert_file_not_contains_line() {
 app_version_property() {
 	local property_name="$1"
 
-	awk -F= -v property_name="$property_name" '
+	git -C "${REPO_ROOT}" show "${HEAD_SHA}:${APP_VERSION_FILE}" \
+		| awk -F= -v property_name="$property_name" '
 		$1 == property_name {
 			value = $2
 			gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
 			print value
-			exit
 		}
-	' "${REPO_ROOT}/${APP_VERSION_FILE}"
+	'
 }
 
 increment_patch_version() {
@@ -184,7 +184,8 @@ run_detector_fixture() {
 		ios-host-runtime)
 			assert_file_contains_line "${temp_dir}/state/impacted-modules.txt" "iosApp" "impacted modules"
 			assert_file_contains_line "${temp_dir}/state/release-impacted-modules.txt" "iosApp" "release impacted modules"
-			assert_file_contains_line "${temp_dir}/state/missing-version-bump.txt" "app" "missing version bump"
+			assert_file_contains_line "${temp_dir}/state/missing-version-bump.txt" "androidVersionCode" "missing version bump"
+			assert_file_contains_line "${temp_dir}/state/missing-version-bump.txt" "iosBuildNumber" "missing version bump"
 			assert_file_contains_line "${temp_dir}/state/e2e-scope.csv" "ios,local-certification-suite,ios-host-runtime" "E2E scope"
 			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildDeviceRelease" "iOS tasks"
 			assert_file_not_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
@@ -216,7 +217,10 @@ run_detector_fixture() {
 			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" ":app:testDebugUnitTest" "Android tasks"
 			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" ":app:bundleRelease" "Android tasks"
 			assert_file_empty "${temp_dir}/state/ios-gradle-tasks.txt" "iOS tasks"
+			assert_file_contains_line "${temp_dir}/state/missing-version-bump.txt" "iosBuildNumber" "missing version bump"
+			assert_file_not_contains_line "${temp_dir}/state/missing-version-bump.txt" "androidVersionCode" "missing version bump"
 			assert_file_contains_line "$github_output_file" "app_version_changed=true" "GitHub output"
+			assert_file_contains_line "$github_output_file" "app_release_build_numbers_changed=false" "GitHub output"
 			;;
 		ios-build-number)
 			assert_file_contains_line "${temp_dir}/state/impacted-modules.txt" "iosApp" "impacted modules"
@@ -225,7 +229,10 @@ run_detector_fixture() {
 			assert_file_empty "${temp_dir}/state/android-gradle-tasks.txt" "Android tasks"
 			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildDeviceRelease" "iOS tasks"
 			assert_file_not_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
+			assert_file_contains_line "${temp_dir}/state/missing-version-bump.txt" "androidVersionCode" "missing version bump"
+			assert_file_not_contains_line "${temp_dir}/state/missing-version-bump.txt" "iosBuildNumber" "missing version bump"
 			assert_file_contains_line "$github_output_file" "app_version_changed=true" "GitHub output"
+			assert_file_contains_line "$github_output_file" "app_release_build_numbers_changed=false" "GitHub output"
 			;;
 		version-name)
 			assert_file_contains_line "${temp_dir}/state/impacted-modules.txt" "app" "impacted modules"
@@ -237,7 +244,24 @@ run_detector_fixture() {
 			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" ":app:bundleRelease" "Android tasks"
 			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildDeviceRelease" "iOS tasks"
 			assert_file_not_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
+			assert_file_contains_line "${temp_dir}/state/missing-version-bump.txt" "androidVersionCode" "missing version bump"
+			assert_file_contains_line "${temp_dir}/state/missing-version-bump.txt" "iosBuildNumber" "missing version bump"
 			assert_file_contains_line "$github_output_file" "app_version_changed=true" "GitHub output"
+			assert_file_contains_line "$github_output_file" "app_release_build_numbers_changed=false" "GitHub output"
+			;;
+		release-build-numbers)
+			assert_file_contains_line "${temp_dir}/state/impacted-modules.txt" "app" "impacted modules"
+			assert_file_contains_line "${temp_dir}/state/impacted-modules.txt" "iosApp" "impacted modules"
+			assert_file_contains_line "${temp_dir}/state/release-impacted-modules.txt" "app" "release impacted modules"
+			assert_file_contains_line "${temp_dir}/state/release-impacted-modules.txt" "iosApp" "release impacted modules"
+			assert_file_empty "${temp_dir}/state/missing-version-bump.txt" "missing version bump"
+			assert_file_empty "${temp_dir}/state/e2e-scope.csv" "E2E scope"
+			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" ":app:testDebugUnitTest" "Android tasks"
+			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" ":app:bundleRelease" "Android tasks"
+			assert_file_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostBuildDeviceRelease" "iOS tasks"
+			assert_file_not_contains_line "${temp_dir}/state/ios-gradle-tasks.txt" "verifyIosHostTypecheck" "iOS tasks"
+			assert_file_contains_line "$github_output_file" "app_version_changed=true" "GitHub output"
+			assert_file_contains_line "$github_output_file" "app_release_build_numbers_changed=true" "GitHub output"
 			;;
 		*)
 			printf 'Unknown detector fixture: %s\n' "$name" >&2
@@ -264,6 +288,13 @@ ios_build_commit="$(
 		"$current_android_version_code" \
 		"$((current_ios_build_number + 1))"
 )"
+release_build_numbers_commit="$(
+	create_app_version_commit \
+		release-build-numbers \
+		"$current_version_name" \
+		"$((current_android_version_code + 1))" \
+		"$((current_ios_build_number + 1))"
+)"
 version_name_commit="$(
 	create_app_version_commit \
 		version-name \
@@ -281,6 +312,7 @@ run_detector_fixture ios-version-xcconfig iosApp/Config/Version.xcconfig
 run_detector_fixture ios-release-signing iosApp/Config/Release.xcconfig "$HEAD_SHA" "$ios_release_signing_commit"
 run_detector_fixture android-version-code "$APP_VERSION_FILE" "$HEAD_SHA" "$android_version_commit"
 run_detector_fixture ios-build-number "$APP_VERSION_FILE" "$HEAD_SHA" "$ios_build_commit"
+run_detector_fixture release-build-numbers "$APP_VERSION_FILE" "$HEAD_SHA" "$release_build_numbers_commit"
 run_detector_fixture version-name "$APP_VERSION_FILE" "$HEAD_SHA" "$version_name_commit"
 
 printf 'Detect changed app shell fixtures passed.\n'

--- a/gradle/app-version.properties
+++ b/gradle/app-version.properties
@@ -1,3 +1,3 @@
 versionName=6.1.5
-androidVersionCode=44
-iosBuildNumber=32
+androidVersionCode=45
+iosBuildNumber=33

--- a/iosApp/Config/Version.xcconfig
+++ b/iosApp/Config/Version.xcconfig
@@ -1,3 +1,3 @@
 // Generated from gradle/app-version.properties. Do not edit directly.
 MARKETING_VERSION = 6.1.5
-CURRENT_PROJECT_VERSION = 32
+CURRENT_PROJECT_VERSION = 33

--- a/iosApp/scripts/ci-upload-ios-appstore.sh
+++ b/iosApp/scripts/ci-upload-ios-appstore.sh
@@ -28,7 +28,6 @@ SKIP_IF_BUILD_EXISTS="${APP_STORE_CONNECT_SKIP_EXISTING_BUILD:-1}"
 CHECK_ONLY="${APP_STORE_CONNECT_CHECK_ONLY:-0}"
 BUILD_EXISTS_FILE="${APP_STORE_CONNECT_BUILD_EXISTS_FILE:-}"
 APP_STORE_CONNECT_API_ROOT="${APP_STORE_CONNECT_API_ROOT:-https://api.appstoreconnect.apple.com/v1}"
-VERSION_NAME="$(get_app_version_name)"
 IOS_BUILD_NUMBER="$(get_ios_build_number)"
 
 log() {
@@ -166,27 +165,20 @@ check_app_store_connect_build_exists() {
 	app_store_connect_get_json "${APP_STORE_CONNECT_API_ROOT}/builds?filter%5Bapp%5D=${app_id}&filter%5Bversion%5D=${IOS_BUILD_NUMBER}&include=preReleaseVersion&limit=200" "$builds_response"
 	existing_build_id="$(
 		jq -r \
-			--arg version_name "$VERSION_NAME" \
 			'[
-				.data[]? as $build
-				| ($build.relationships.preReleaseVersion.data.id // "") as $pre_release_id
-				| select(
-					$pre_release_id != "" and
-					any(.included[]?; .type == "preReleaseVersions" and .id == $pre_release_id and .attributes.version == $version_name)
-				)
-				| $build.id
+				.data[]?.id
 			][0] // empty' \
 			"$builds_response"
 	)"
 
 	if [[ -n "$existing_build_id" ]]; then
 		write_build_exists_state "true" "$existing_build_id"
-		log "App Store Connect build ${VERSION_NAME} (${IOS_BUILD_NUMBER}) already exists for ${IOS_BUNDLE_IDENTIFIER}; skipping archive and upload."
+		log "App Store Connect build number ${IOS_BUILD_NUMBER} already exists for ${IOS_BUNDLE_IDENTIFIER}; skipping archive and upload."
 		return 0
 	fi
 
 	write_build_exists_state "false" ""
-	log "App Store Connect build ${VERSION_NAME} (${IOS_BUILD_NUMBER}) does not exist for ${IOS_BUNDLE_IDENTIFIER}; archive/upload is required."
+	log "App Store Connect build number ${IOS_BUILD_NUMBER} does not exist for ${IOS_BUNDLE_IDENTIFIER}; archive/upload is required."
 	return 1
 }
 


### PR DESCRIPTION
## Summary

- Bumps `androidVersionCode` from 44 to 45 and `iosBuildNumber` from 32 to 33 while keeping `versionName` at 6.1.5.
- Requires release-impacting changes to include both platform build numbers, not only one version field.
- Makes the iOS App Store Connect existing-build check independent of marketing version by checking build number existence directly.
- Adds shell fixtures for one-number-only failures, both-number success, and iOS build number reuse across marketing versions.

## Validation

- `bash .github/scripts/validate-ci-config.sh`
- `bash .github/scripts/test-detect-changed-app.sh`
- `bash .github/scripts/test-appstore-connect-check.sh`
- `bash .github/scripts/validate-app-version.sh`
- `STATE_DIR=/tmp/tuindice-detect-release-build-number-gates bash .github/scripts/detect-changed-app.sh origin/production HEAD`

## E2E

The detector reported an empty E2E scope for this diff, so local E2E certification is not required.
