### PR TITLE
Improve Maestro progress output

### DIFF
--- a/.github/scripts/deploy-production.sh
+++ b/.github/scripts/deploy-production.sh
@@ -54,22 +54,50 @@ create_release_tag() {
 }
 
 run_deploy_preflight() {
+	local detect_output_file
+	local has_relevant_changes
+	local app_version_changed
+	local has_release_impact
+	local should_deploy
+
 	BEFORE_SHA="$(resolve_deploy_diff_base_sha)"
 	[[ -n "$BEFORE_SHA" ]] || die "Unable to resolve previous production SHA."
 
 	DETECT_STATE_DIR="${STATE_DIR}/detect"
 	mkdir -p "$DETECT_STATE_DIR"
+	detect_output_file="${STATE_DIR}/detect-output.env"
 
-	STATE_DIR="$DETECT_STATE_DIR" bash "${SCRIPT_DIR}/detect-changed-app.sh" "$BEFORE_SHA" "$TARGET_GIT_SHA"
+	GITHUB_OUTPUT="$detect_output_file" \
+	STATE_DIR="$DETECT_STATE_DIR" \
+		bash "${SCRIPT_DIR}/detect-changed-app.sh" "$BEFORE_SHA" "$TARGET_GIT_SHA"
+
+	has_relevant_changes="$(awk -F= '$1 == "has_relevant_changes" { print $2 }' "$detect_output_file")"
+	app_version_changed="$(awk -F= '$1 == "app_version_changed" { print $2 }' "$detect_output_file")"
+	has_release_impact="$(awk -F= '$1 == "has_release_impact" { print $2 }' "$detect_output_file")"
+
+	should_deploy=false
+	if [[ "$app_version_changed" == "true" || "$has_release_impact" == "true" ]]; then
+		should_deploy=true
+	fi
+
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		printf 'should_deploy=%s\n' "$should_deploy" >>"$GITHUB_OUTPUT"
+	fi
 
 	MISSING_VERSION_BUMP_FILE="${DETECT_STATE_DIR}/missing-version-bump.txt" \
 	E2E_ANDROID_CONTEXTS_FILE="${DETECT_STATE_DIR}/e2e-android-contexts.txt" \
 	E2E_IOS_CONTEXTS_FILE="${DETECT_STATE_DIR}/e2e-ios-contexts.txt" \
 	REQUIRES_E2E_CERTIFICATION="false" \
-	HAS_RELEVANT_CHANGES="true" \
+	HAS_RELEVANT_CHANGES="$has_relevant_changes" \
+	APP_VERSION_CHANGED="$app_version_changed" \
+	HAS_RELEASE_IMPACT="$has_release_impact" \
 	TARGET_GIT_SHA="$TARGET_GIT_SHA" \
 	SKIP_E2E_STATUS_CHECK=1 \
 		bash "${SCRIPT_DIR}/preflight-production.sh"
+
+	if [[ "$should_deploy" != "true" ]]; then
+		info "No app version or runtime release changes detected; production deploy jobs should be skipped."
+	fi
 }
 
 run_android_deploy() {

--- a/.github/scripts/detect-changed-app.sh
+++ b/.github/scripts/detect-changed-app.sh
@@ -376,7 +376,6 @@ classify_changed_file() {
 		e2e/scripts/*|e2e/platform/*)
 			E2E_CONTRACT_TOUCHED=true
 			HAS_RELEVANT_CHANGES=true
-			append_e2e_scope all local-certification-suite "e2e-runner"
 			return 0
 			;;
 		mocks/*)

--- a/.github/scripts/preflight-production.sh
+++ b/.github/scripts/preflight-production.sh
@@ -16,6 +16,8 @@ E2E_ANDROID_CONTEXTS_FILE="${E2E_ANDROID_CONTEXTS_FILE:-}"
 E2E_IOS_CONTEXTS_FILE="${E2E_IOS_CONTEXTS_FILE:-}"
 REQUIRES_E2E_CERTIFICATION="${REQUIRES_E2E_CERTIFICATION:-false}"
 HAS_RELEVANT_CHANGES="${HAS_RELEVANT_CHANGES:-true}"
+APP_VERSION_CHANGED="${APP_VERSION_CHANGED:-true}"
+HAS_RELEASE_IMPACT="${HAS_RELEASE_IMPACT:-true}"
 SUMMARY_FILE="${SUMMARY_FILE:-${GITHUB_STEP_SUMMARY:-${RUNNER_TEMP:-/tmp}/preflight-production-summary.md}}"
 TARGET_GIT_SHA="${TARGET_GIT_SHA:-${GITHUB_SHA:-$(git rev-parse HEAD)}}"
 E2E_REUSE_BASE_SHA="${E2E_REUSE_BASE_SHA:-}"
@@ -310,7 +312,11 @@ if [[ "$HAS_RELEVANT_CHANGES" != "true" ]]; then
 	exit 0
 fi
 
-bash "${SCRIPT_DIR}/validate-app-version.sh"
+if [[ "$APP_VERSION_CHANGED" == "true" || "$HAS_RELEASE_IMPACT" == "true" ]]; then
+	bash "${SCRIPT_DIR}/validate-app-version.sh"
+else
+	info "Skipping app version validation because no app version or runtime release changes were detected."
+fi
 
 if file_has_entries "$MISSING_VERSION_BUMP_FILE"; then
 	die "Runtime app changes or app version changes require both androidVersionCode and iosBuildNumber to change. Bump the missing build number(s) in $(app_version_file) before deploying."

--- a/.github/scripts/test-detect-changed-app.sh
+++ b/.github/scripts/test-detect-changed-app.sh
@@ -171,6 +171,19 @@ run_detector_fixture() {
 	) >"$output_file" 2>&1
 
 	case "$name" in
+		e2e-runner)
+			assert_file_empty "${temp_dir}/state/impacted-modules.txt" "impacted modules"
+			assert_file_empty "${temp_dir}/state/release-impacted-modules.txt" "release impacted modules"
+			assert_file_empty "${temp_dir}/state/missing-version-bump.txt" "missing version bump"
+			assert_file_contains_line "${temp_dir}/state/e2e-suites.txt" "local-certification-suite" "E2E suites"
+			assert_file_contains_line "${temp_dir}/state/e2e-scope.csv" "android,local-certification-suite,e2e-runner" "E2E scope"
+			assert_file_contains_line "${temp_dir}/state/e2e-scope.csv" "ios,local-certification-suite,e2e-runner" "E2E scope"
+			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" "verifyE2eContract" "Android tasks"
+			assert_file_empty "${temp_dir}/state/ios-gradle-tasks.txt" "iOS tasks"
+			assert_file_contains_line "$github_output_file" "app_version_changed=false" "GitHub output"
+			assert_file_contains_line "$github_output_file" "has_release_impact=false" "GitHub output"
+			assert_file_contains_line "$github_output_file" "requires_e2e_certification=true" "GitHub output"
+			;;
 		ios-script-tooling)
 			assert_file_empty "${temp_dir}/state/impacted-modules.txt" "impacted modules"
 			assert_file_empty "${temp_dir}/state/release-impacted-modules.txt" "release impacted modules"
@@ -306,6 +319,7 @@ ios_release_signing_commit="$(
 	create_ios_release_signing_commit ios-release-signing
 )"
 
+run_detector_fixture e2e-runner e2e/scripts/common.sh
 run_detector_fixture ios-script-tooling iosApp/scripts/ci-upload-ios-appstore.sh
 run_detector_fixture ios-host-runtime iosApp/Sources/TuIndiceHost/TuIndiceAppBootstrap.swift
 run_detector_fixture ios-version-xcconfig iosApp/Config/Version.xcconfig

--- a/.github/scripts/test-detect-changed-app.sh
+++ b/.github/scripts/test-detect-changed-app.sh
@@ -175,14 +175,13 @@ run_detector_fixture() {
 			assert_file_empty "${temp_dir}/state/impacted-modules.txt" "impacted modules"
 			assert_file_empty "${temp_dir}/state/release-impacted-modules.txt" "release impacted modules"
 			assert_file_empty "${temp_dir}/state/missing-version-bump.txt" "missing version bump"
-			assert_file_contains_line "${temp_dir}/state/e2e-suites.txt" "local-certification-suite" "E2E suites"
-			assert_file_contains_line "${temp_dir}/state/e2e-scope.csv" "android,local-certification-suite,e2e-runner" "E2E scope"
-			assert_file_contains_line "${temp_dir}/state/e2e-scope.csv" "ios,local-certification-suite,e2e-runner" "E2E scope"
+			assert_file_empty "${temp_dir}/state/e2e-suites.txt" "E2E suites"
+			assert_file_empty "${temp_dir}/state/e2e-scope.csv" "E2E scope"
 			assert_file_contains_line "${temp_dir}/state/android-gradle-tasks.txt" "verifyE2eContract" "Android tasks"
 			assert_file_empty "${temp_dir}/state/ios-gradle-tasks.txt" "iOS tasks"
 			assert_file_contains_line "$github_output_file" "app_version_changed=false" "GitHub output"
 			assert_file_contains_line "$github_output_file" "has_release_impact=false" "GitHub output"
-			assert_file_contains_line "$github_output_file" "requires_e2e_certification=true" "GitHub output"
+			assert_file_contains_line "$github_output_file" "requires_e2e_certification=false" "GitHub output"
 			;;
 		ios-script-tooling)
 			assert_file_empty "${temp_dir}/state/impacted-modules.txt" "impacted modules"

--- a/.github/scripts/test-preflight-production.sh
+++ b/.github/scripts/test-preflight-production.sh
@@ -129,6 +129,8 @@ SH
 		E2E_IOS_CONTEXTS_FILE="${ios_contexts_file}" \
 		REQUIRES_E2E_CERTIFICATION="true" \
 		HAS_RELEVANT_CHANGES="true" \
+		APP_VERSION_CHANGED="false" \
+		HAS_RELEASE_IMPACT="false" \
 		SUMMARY_FILE="${summary_file}" \
 		bash ./.github/scripts/preflight-production.sh
 	) >"${output_file}" 2>&1
@@ -149,6 +151,11 @@ SH
 
 	case "${name}" in
 		reuse-success)
+			if ! grep -q 'Skipping app version validation' "${output_file}"; then
+				printf 'Preflight fixture %s did not skip app version validation for E2E-only scope.\n' "${name}" >&2
+				cat "${output_file}" >&2
+				exit 1
+			fi
 			if grep -q 'Missing successful E2E status' "${output_file}"; then
 				printf 'Preflight fixture %s unexpectedly reported missing evidence.\n' "${name}" >&2
 				cat "${output_file}" >&2

--- a/.github/scripts/validate-app-version.sh
+++ b/.github/scripts/validate-app-version.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=.github/scripts/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
+SKIP_APP_VERSION_TAG_CONFLICT_CHECK="${SKIP_APP_VERSION_TAG_CONFLICT_CHECK:-0}"
+
 bash "${SCRIPT_DIR}/sync-app-version.sh"
 
 VERSION_NAME="$(get_app_version_name)"
@@ -41,7 +43,9 @@ fi
 TAG_NAME="$(app_tag_name "$VERSION_NAME")"
 TAG_TARGET="$(existing_tag_target "$TAG_NAME" || true)"
 
-if [[ -n "$TAG_TARGET" && -n "${TARGET_GIT_SHA:-${GITHUB_SHA:-}}" ]]; then
+if [[ "$SKIP_APP_VERSION_TAG_CONFLICT_CHECK" == "1" ]]; then
+	info "Skipping app version tag conflict check for non-release validation."
+elif [[ -n "$TAG_TARGET" && -n "${TARGET_GIT_SHA:-${GITHUB_SHA:-}}" ]]; then
 	TARGET_SHA="${TARGET_GIT_SHA:-${GITHUB_SHA:-}}"
 	if [[ "$TAG_TARGET" != "$TARGET_SHA" ]]; then
 		die "Tag ${TAG_NAME} already exists at ${TAG_TARGET}. Bump $(app_version_file) before deploying."

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,6 +24,8 @@ jobs:
     name: Deploy preflight
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    outputs:
+      should_deploy: ${{ steps.deploy-preflight.outputs.should_deploy }}
 
     steps:
       - name: Check out repository
@@ -33,6 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run deploy preflight
+        id: deploy-preflight
         env:
           TARGET_GIT_SHA: ${{ github.sha }}
           DEPLOY_PRODUCTION_PHASE: preflight
@@ -44,6 +47,7 @@ jobs:
     name: Deploy Android
     runs-on: ubuntu-24.04
     needs: deploy-preflight
+    if: needs.deploy-preflight.outputs.should_deploy == 'true'
     environment: production
     timeout-minutes: 90
 
@@ -103,6 +107,7 @@ jobs:
     name: Deploy iOS
     runs-on: macos-26
     needs: deploy-preflight
+    if: needs.deploy-preflight.outputs.should_deploy == 'true'
     environment: production
     timeout-minutes: 120
 
@@ -221,8 +226,10 @@ jobs:
     name: Tag release
     runs-on: ubuntu-24.04
     needs:
+      - deploy-preflight
       - deploy-android
       - deploy-ios
+    if: needs.deploy-preflight.outputs.should_deploy == 'true'
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/preflight-production-pr.yml
+++ b/.github/workflows/preflight-production-pr.yml
@@ -67,6 +67,8 @@ jobs:
           E2E_IOS_CONTEXTS_FILE: ${{ steps.changes.outputs.e2e_ios_contexts_file }}
           REQUIRES_E2E_CERTIFICATION: ${{ steps.changes.outputs.requires_e2e_certification }}
           HAS_RELEVANT_CHANGES: ${{ steps.changes.outputs.has_relevant_changes }}
+          APP_VERSION_CHANGED: ${{ steps.changes.outputs.app_version_changed }}
+          HAS_RELEASE_IMPACT: ${{ steps.changes.outputs.has_release_impact }}
           E2E_REUSE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail

--- a/.github/workflows/preflight-production-pr.yml
+++ b/.github/workflows/preflight-production-pr.yml
@@ -23,6 +23,8 @@ jobs:
       ios_tasks: ${{ steps.changes.outputs.ios_tasks }}
       ios_ci_scripts_touched: ${{ steps.changes.outputs.ios_ci_scripts_touched }}
       has_relevant_changes: ${{ steps.changes.outputs.has_relevant_changes }}
+      app_version_changed: ${{ steps.changes.outputs.app_version_changed }}
+      has_release_impact: ${{ steps.changes.outputs.has_release_impact }}
 
     steps:
       - name: Check out repository
@@ -123,6 +125,7 @@ jobs:
           TU_INDICE_KEY_ALIAS: ${{ secrets.TU_INDICE_KEY_ALIAS }}
           TU_INDICE_KEY_PASSWORD: ${{ secrets.TU_INDICE_KEY_PASSWORD }}
           TU_INDICE_KEY_STORE_PASSWORD: ${{ secrets.TU_INDICE_KEY_STORE_PASSWORD }}
+          SKIP_APP_VERSION_TAG_CONFLICT_CHECK: ${{ (needs.shared-preflight.outputs.app_version_changed != 'true' && needs.shared-preflight.outputs.has_release_impact != 'true') && '1' || '0' }}
         run: |
           set -euo pipefail
           bash ./.github/scripts/run-gradle-with-retry.sh \

--- a/e2e/scripts/common.sh
+++ b/e2e/scripts/common.sh
@@ -55,43 +55,122 @@ elapsed_label() {
 	printf '%dm %02ds' "$((elapsed_seconds / 60))" "$((elapsed_seconds % 60))"
 }
 
-maestro_direct_flow_plan() {
+display_path() {
+	local path="$1"
+
+	if [[ -z "${path}" ]]; then
+		printf '-'
+		return 0
+	fi
+
+	case "${path}" in
+		"${REPO_ROOT}/"*)
+			printf '%s' "${path#"${REPO_ROOT}/"}"
+			;;
+		"${E2E_TMP_DIR}/"*)
+			printf '%s' "${path#"${E2E_TMP_DIR}/"}"
+			;;
+		*)
+			printf '%s' "${path}"
+			;;
+	esac
+}
+
+maestro_direct_flow_entries() {
 	local suite_path="$1"
-	local suite_dir
-	local resolved_dir
-	local flow
-	local flow_count=0
 
 	[[ -f "${suite_path}" ]] || return 0
-	suite_dir="$(cd "$(dirname "${suite_path}")" && pwd -P)"
-	log "Maestro suite plan for $(basename "${suite_path}"):"
+	awk '
+		/^[[:space:]]*-[[:space:]]*runFlow:[[:space:]]*[^[:space:]]/ {
+			sub(/^[[:space:]]*-[[:space:]]*runFlow:[[:space:]]*/, "")
+			gsub(/^["'\''[:space:]]+|["'\''[:space:]]+$/, "")
+			print
+		}
+	' "${suite_path}"
+}
+
+maestro_flow_label() {
+	local flow="$1"
+	flow="${flow##*/}"
+	flow="${flow%.yaml}"
+	printf '%s' "${flow}"
+}
+
+maestro_direct_flow_plan() {
+	local suite_path="$1"
+	local suite_name
+	local preview_limit="${E2E_MAESTRO_FLOW_PREVIEW_LIMIT:-6}"
+	local flow
+	local flow_count=0
+	local preview_count=0
+	local preview=""
+
+	[[ -f "${suite_path}" ]] || return 0
+	suite_name="$(basename "${suite_path}")"
+	if [[ ! "${preview_limit}" =~ ^[0-9]+$ ]]; then
+		preview_limit=6
+	fi
+
 	while IFS= read -r flow; do
 		[[ -n "${flow}" ]] || continue
 		flow_count=$((flow_count + 1))
-		case "${flow}" in
-			/*)
-				log "  ${flow_count}. ${flow}"
-				;;
-			*)
-				if resolved_dir="$(cd "${suite_dir}" && cd "$(dirname "${flow}")" && pwd -P 2>/dev/null)"; then
-					log "  ${flow_count}. ${flow} (${resolved_dir}/$(basename "${flow}"))"
-				else
-					log "  ${flow_count}. ${flow} (${suite_dir}/${flow})"
-				fi
-				;;
-		esac
-	done < <(
-		awk '
-			/^[[:space:]]*-[[:space:]]*runFlow:[[:space:]]*[^[:space:]]/ {
-				sub(/^[[:space:]]*-[[:space:]]*runFlow:[[:space:]]*/, "")
-				gsub(/^["'\''[:space:]]+|["'\''[:space:]]+$/, "")
-				print
-			}
-		' "${suite_path}"
-	)
+		if [[ "${preview_count}" -lt "${preview_limit}" ]]; then
+			if [[ -n "${preview}" ]]; then
+				preview="${preview}, "
+			fi
+			preview="${preview}$(maestro_flow_label "${flow}")"
+			preview_count=$((preview_count + 1))
+		fi
+	done < <(maestro_direct_flow_entries "${suite_path}")
 
 	if [[ "${flow_count}" == "0" ]]; then
-		log "  inline commands only"
+		log "Maestro suite: ${suite_name}; inline commands only."
+	else
+		log "Maestro suite: ${suite_name}; top-level runFlow entries=${flow_count}."
+		if [[ "${preview_count}" -gt "0" ]]; then
+			if [[ "${flow_count}" -gt "${preview_count}" ]]; then
+				preview="${preview}, +$((flow_count - preview_count)) more"
+			fi
+			log "Maestro flow preview: ${preview}."
+		else
+			log "Maestro flow preview disabled; set E2E_MAESTRO_FLOW_PREVIEW_LIMIT to show entries."
+		fi
+	fi
+
+	if [[ "${E2E_MAESTRO_PRINT_FLOW_PLAN:-0}" == "1" && "${flow_count}" != "0" ]]; then
+		local index=0
+		while IFS= read -r flow; do
+			[[ -n "${flow}" ]] || continue
+			index=$((index + 1))
+			log "  ${index}/${flow_count} ${flow}"
+		done < <(maestro_direct_flow_entries "${suite_path}")
+	fi
+}
+
+log_maestro_start() {
+	local platform="$1"
+	local suite_path="$2"
+	local log_file="$3"
+	local report_file="${E2E_MAESTRO_REPORT_FILE:-}"
+	local test_output_dir="$4"
+	local debug_output_dir="$5"
+	local interval_seconds="$6"
+
+	log "${platform} Maestro start: suite=$(basename "${suite_path}"), progressInterval=${interval_seconds}s."
+	log "${platform} Maestro outputs: log=$(display_path "${log_file}"), report=$(display_path "${report_file}"), artifacts=$(display_path "${test_output_dir}"), debug=$(display_path "${debug_output_dir}")."
+}
+
+log_maestro_finish() {
+	local platform="$1"
+	local status="$2"
+	local started_at="$3"
+	local elapsed
+
+	elapsed="$(elapsed_label "$(($(date +%s) - started_at))")"
+	if [[ "${status}" == "0" ]]; then
+		log "${platform} Maestro finished: passed in ${elapsed}."
+	else
+		log "${platform} Maestro finished: failed with exit ${status} after ${elapsed}."
 	fi
 }
 
@@ -148,16 +227,16 @@ log_maestro_progress() {
 				;;
 		esac
 		if [[ -n "${latest_line}" ]]; then
-			log "${platform} Maestro still running after ${elapsed}; latest artifact $(basename "${latest_file}"): ${latest_line}"
+			log "${platform} Maestro running ${elapsed}; artifact=$(display_path "${latest_file}"); last='${latest_line}'."
 		else
-			log "${platform} Maestro still running after ${elapsed}; latest artifact $(basename "${latest_file}") updated."
+			log "${platform} Maestro running ${elapsed}; artifact=$(display_path "${latest_file}") updated."
 		fi
 		return 0
 	fi
 
 	wiremock_request="$(latest_wiremock_request)"
 	if [[ -n "${wiremock_request}" ]]; then
-		log "${platform} Maestro still running after ${elapsed}; latest WireMock request: ${wiremock_request}"
+		log "${platform} Maestro running ${elapsed}; latest WireMock request: ${wiremock_request}."
 		return 0
 	fi
 
@@ -165,9 +244,9 @@ log_maestro_progress() {
 		latest_line="$(tail -n 1 "${log_file}" 2>/dev/null | tr -d '\r' | cut -c1-220)"
 	fi
 	if [[ -n "${latest_line}" ]]; then
-		log "${platform} Maestro still running after ${elapsed}; latest log line: ${latest_line}"
+		log "${platform} Maestro running ${elapsed}; latest log='${latest_line}'."
 	else
-		log "${platform} Maestro still running after ${elapsed}; waiting for Maestro output."
+		log "${platform} Maestro running ${elapsed}; waiting for first Maestro output."
 	fi
 }
 
@@ -185,6 +264,7 @@ run_maestro_with_progress() {
 	local status=0
 
 	maestro_direct_flow_plan "${suite_path}"
+	log_maestro_start "${platform}" "${suite_path}" "${log_file}" "${test_output_dir}" "${debug_output_dir}" "${interval_seconds}"
 	started_at="$(date +%s)"
 	(
 		set -o pipefail
@@ -205,6 +285,7 @@ run_maestro_with_progress() {
 	wait "${command_pid}" || status="$?"
 	kill "${monitor_pid}" >/dev/null 2>&1 || true
 	wait "${monitor_pid}" >/dev/null 2>&1 || true
+	log_maestro_finish "${platform}" "${status}" "${started_at}"
 	return "${status}"
 }
 

--- a/e2e/scripts/run-maestro-android.sh
+++ b/e2e/scripts/run-maestro-android.sh
@@ -6,6 +6,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 require_command adb
 require_command maestro
 
+log "Android Maestro setup: WireMock=${E2E_WIREMOCK_URL}; appId=${E2E_APP_ID}."
 register_wiremock_cleanup
 "${SCRIPT_DIR}/start-wiremock.sh"
 reset_wiremock
@@ -19,7 +20,7 @@ if [[ ! -f "${APK_PATH}" ]]; then
 	exit 1
 fi
 
-log "Installing ${APK_PATH}."
+log "Installing Android APK: $(display_path "${APK_PATH}")."
 adb install -r "${APK_PATH}" >/dev/null
 "${SCRIPT_DIR}/reset-android-app.sh"
 
@@ -45,7 +46,6 @@ if [[ -n "${E2E_MAESTRO_DEBUG_OUTPUT_DIR:-}" ]]; then
 fi
 maestro_args+=("${E2E_MAESTRO_SUITE}")
 
-log "Running Maestro Android suite ${E2E_MAESTRO_SUITE}."
 run_maestro_with_progress \
 	"Android" \
 	"${MAESTRO_LOG_FILE}" \

--- a/e2e/scripts/run-maestro-evidence-local.sh
+++ b/e2e/scripts/run-maestro-evidence-local.sh
@@ -151,10 +151,16 @@ scope_status() {
 android_scope="$(scope_status android)"
 ios_scope="$(scope_status ios)"
 
+if [[ -n "${REQUESTED_E2E_MAESTRO_SUITE}" ]]; then
+	log "Local E2E evidence plan: requestedSuite=$(basename "${REQUESTED_E2E_MAESTRO_SUITE}"); android=${android_scope} tcp:${ANDROID_WIREMOCK_PORT}; ios=${ios_scope} tcp:${IOS_WIREMOCK_PORT}."
+else
+	log "Local E2E evidence plan: scope-aware suites; android=${android_scope} tcp:${ANDROID_WIREMOCK_PORT}; ios=${ios_scope} tcp:${IOS_WIREMOCK_PORT}."
+fi
+
 if [[ "${E2E_SKIP_ANDROID:-0}" == "1" ]]; then
 	log "Skipping Android Maestro evidence because E2E_SKIP_ANDROID=1."
 elif [[ "$android_scope" == "required" ]]; then
-	log "Starting Android Maestro evidence in parallel on WireMock tcp:${ANDROID_WIREMOCK_PORT}."
+	log "Starting Android evidence worker."
 	run_platform_evidence android "${ANDROID_WIREMOCK_PORT}" "${ANDROID_TMP_DIR}" &
 	android_pid="$!"
 else
@@ -164,7 +170,7 @@ fi
 if [[ "$ios_scope" != "required" ]]; then
 	log "Skipping iOS Maestro evidence because no iOS E2E suites are required for this diff."
 elif is_macos && command -v xcrun >/dev/null 2>&1; then
-	log "Starting iOS Maestro evidence in parallel on WireMock tcp:${IOS_WIREMOCK_PORT}."
+	log "Starting iOS evidence worker."
 	run_platform_evidence ios "${IOS_WIREMOCK_PORT}" "${IOS_TMP_DIR}" &
 	ios_pid="$!"
 elif [[ "${E2E_STRICT_IOS:-0}" == "1" ]]; then

--- a/e2e/scripts/run-maestro-evidence.sh
+++ b/e2e/scripts/run-maestro-evidence.sh
@@ -134,10 +134,18 @@ publish_github_statuses() {
 	local description="$2"
 	local include_covered="${3:-1}"
 	local context
+	local contexts=()
 
 	while IFS= read -r context; do
 		[[ -n "${context}" ]] || continue
-		log "Publishing GitHub commit status ${context}=${state}."
+		contexts+=("${context}")
+	done < <(covered_status_contexts "${include_covered}")
+
+	log "Publishing ${#contexts[@]} GitHub commit status context(s) as ${state}."
+	for context in "${contexts[@]}"; do
+		if [[ "${E2E_VERBOSE_STATUS_PUBLISHING:-0}" == "1" ]]; then
+			log "  ${context}=${state}"
+		fi
 		gh api \
 			-X POST \
 			"repos/{owner}/{repo}/statuses/${COMMIT_SHA}" \
@@ -145,7 +153,7 @@ publish_github_statuses() {
 			-f context="${context}" \
 			-f description="${description}" \
 			>/dev/null
-	done < <(covered_status_contexts "${include_covered}")
+	done
 }
 
 maestro_report_has_no_failures() {
@@ -207,6 +215,9 @@ run_suite_evidence() {
 	local android_version_code
 	local ios_build_number
 	local publish_description
+	local started_seconds
+	local finished_seconds
+	local duration_label
 
 	SUITE_ID="$(basename "${suite_path}" .yaml)"
 	E2E_FINGERPRINT="$("${SCRIPT_DIR}/e2e-fingerprint.sh" "${PLATFORM}" "${SUITE_ID}" "${COMMIT_SHA}")"
@@ -229,12 +240,16 @@ run_suite_evidence() {
 	export E2E_MAESTRO_TEST_OUTPUT_DIR="${TEST_OUTPUT_DIR}"
 	export E2E_MAESTRO_DEBUG_OUTPUT_DIR="${DEBUG_OUTPUT_DIR}"
 
+	log "E2E evidence start: ${PLATFORM}/${SUITE_ID}; commit=${COMMIT_SHA:0:7}; context=${STATUS_CONTEXT}."
 	started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	started_seconds="$(date +%s)"
 	set +e
 	bash "${SCRIPT_DIR}/run-maestro-${PLATFORM}.sh"
 	status=$?
 	set -e
 	finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	finished_seconds="$(date +%s)"
+	duration_label="$(elapsed_label "$((finished_seconds - started_seconds))")"
 
 	if maestro_nonzero_after_passed_flow_is_recoverable "$status" "$LOG_FILE" "$REPORT_FILE"; then
 		log "Maestro exited with ${status} after reporting a passing flow and writing a clean JUnit report; treating evidence as passed."
@@ -328,7 +343,11 @@ run_suite_evidence() {
 		log "Skipping GitHub commit status publishing because E2E failed."
 	fi
 
-	log "E2E evidence manifest: ${MANIFEST_FILE}"
+	if [[ "$status" == "0" ]]; then
+		log "E2E evidence passed: ${PLATFORM}/${SUITE_ID} in ${duration_label}; manifest=$(display_path "${MANIFEST_FILE}")."
+	else
+		log "E2E evidence failed: ${PLATFORM}/${SUITE_ID} in ${duration_label}; manifest=$(display_path "${MANIFEST_FILE}")."
+	fi
 	return "$status"
 }
 
@@ -355,6 +374,8 @@ if [[ "${#suites[@]}" == "0" ]]; then
 	exit 0
 fi
 
+log "${PLATFORM} E2E evidence suites: ${suites[*]}."
+
 if [[ "${#suites[@]}" -gt 1 && -n "${E2E_CERTIFICATION_DIR:-}" ]]; then
 	printf 'E2E_CERTIFICATION_DIR cannot be shared by multi-suite smart evidence. Set E2E_MAESTRO_SUITE or unset E2E_CERTIFICATION_DIR.\n' >&2
 	exit 1
@@ -367,7 +388,6 @@ for suite in "${suites[@]}"; do
 		exit 1
 	fi
 
-	log "Running smart ${PLATFORM} E2E evidence suite ${suite}."
 	run_suite_evidence "$suite_path" || overall_status="$?"
 done
 

--- a/e2e/scripts/run-maestro-ios.sh
+++ b/e2e/scripts/run-maestro-ios.sh
@@ -11,6 +11,7 @@ fi
 require_command maestro
 require_command xcrun
 
+log "iOS Maestro setup: WireMock=${E2E_WIREMOCK_URL}; bundleId=${E2E_IOS_BUNDLE_ID}; requestedDevice=${E2E_IOS_DEVICE_ID}."
 register_wiremock_cleanup
 "${SCRIPT_DIR}/start-wiremock.sh"
 reset_wiremock
@@ -25,7 +26,7 @@ if [[ ! -d "${APP_PATH}" ]]; then
 fi
 
 "${SCRIPT_DIR}/reset-ios-app.sh"
-log "Installing ${APP_PATH} on ${E2E_IOS_DEVICE_ID}."
+log "Installing iOS app: $(display_path "${APP_PATH}") on ${E2E_IOS_DEVICE_ID}."
 xcrun simctl install "${E2E_IOS_DEVICE_ID}" "${APP_PATH}"
 
 MAESTRO_IOS_DEVICE_ID="${E2E_IOS_DEVICE_ID}"
@@ -60,7 +61,7 @@ if [[ -n "${E2E_MAESTRO_DEBUG_OUTPUT_DIR:-}" ]]; then
 fi
 maestro_args+=("${E2E_MAESTRO_SUITE}")
 
-log "Running Maestro iOS suite ${E2E_MAESTRO_SUITE} on ${MAESTRO_IOS_DEVICE_ID}."
+log "iOS Maestro resolved device: ${MAESTRO_IOS_DEVICE_ID}."
 run_maestro_with_progress \
 	"iOS" \
 	"${MAESTRO_LOG_FILE}" \


### PR DESCRIPTION
## Summary

- Compact Maestro startup output with suite name, top-level runFlow count, bounded flow preview, and relative output paths.
- Add useful evidence lifecycle messages with commit, status context, duration, and manifest path.
- Summarize GitHub status publishing and keep per-context details behind a verbose flag.
- Clarify local Android/iOS evidence worker startup without flooding the terminal.

## Validation

- `bash -n` for the modified E2E scripts.
- `./gradlew --console=plain verifyE2eContract`.